### PR TITLE
testing stuff for itip_sanitize_cn_before_send

### DIFF
--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -116,6 +116,7 @@ sub new
     $config->set(icalendar_max_size => 100000);
     $config->set(event_extra_params => 'vnd.cmu.davFilename vnd.cmu.davUid');
     $config->set(event_groups => 'calendar');
+    $config->set(imipnotifier => 'imip');
     return $class->SUPER::new({
         config => $config,
         adminstore => 1,

--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -111,6 +111,7 @@ sub new
     $config->set(caldav_realm => 'Cassandane');
     $config->set(httpmodules => 'caldav');
     $config->set(calendar_user_address_set => 'example.com');
+    $config->set(defaultdomain => 'example.com');
     $config->set(httpallowcompress => 'no');
     $config->set(caldav_historical_age => -1);
     $config->set(icalendar_max_size => 100000);

--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -111,7 +111,6 @@ sub new
     $config->set(caldav_realm => 'Cassandane');
     $config->set(httpmodules => 'caldav');
     $config->set(calendar_user_address_set => 'example.com');
-    $config->set(defaultdomain => 'example.com');
     $config->set(httpallowcompress => 'no');
     $config->set(caldav_historical_age => -1);
     $config->set(icalendar_max_size => 100000);

--- a/cassandane/Cassandane/Cyrus/Caldav.pm
+++ b/cassandane/Cassandane/Cyrus/Caldav.pm
@@ -138,6 +138,21 @@ sub tear_down
     $self->SUPER::tear_down();
 }
 
+sub skip_check
+{
+    my ($self) = @_;
+
+    # XXX skip tests that would hang in verbose mode for now -- see
+    # XXX detailed comment at MaxMessages::put_submission
+    if (get_verbose()
+        && $self->{_name} eq 'test_imip_quote_cn')
+    {
+        return 'test would hang in verbose mode';
+    }
+
+    return undef;
+}
+
 sub _all_keys_match
 {
     my $a = shift;

--- a/cassandane/Cassandane/Cyrus/JMAPBackup.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPBackup.pm
@@ -66,6 +66,7 @@ sub new
                  conversations => 'yes',
                  httpmodules => 'carddav caldav jmap',
                  httpallowcompress => 'no',
+                 imipnotifier => 'imip',
                  notesmailbox => 'Notes',
                  jmap_nonstandard_extensions => 'yes');
 

--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -71,6 +71,7 @@ sub new
                  conversations => 'yes',
                  httpmodules => 'carddav caldav jmap',
                  httpallowcompress => 'no',
+                 imipnotifier => 'imip',
                  sync_log => 'yes',
                  jmap_nonstandard_extensions => 'yes',
                  defaultdomain => 'example.com');

--- a/cassandane/Cassandane/Cyrus/JMAPEmail.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPEmail.pm
@@ -71,6 +71,7 @@ sub new
                  defaultdomain => 'example.com',
                  httpallowcompress => 'no',
                  httpmodules => 'carddav caldav jmap',
+                 imipnotifier => 'imip',
                  icalendar_max_size => 100000,
                  jmap_nonstandard_extensions => 'yes',
                  jmapsubmission_deleteonsend => 'no',

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -695,6 +695,10 @@ sub _generate_imapd_conf
 {
     my ($self, $config, $prefix) = @_;
 
+    # Be very careful about setting $config options in this
+    # function.  Anything that is set here cannot be varied
+    # per test!
+
     if (defined $self->{services}->{http}) {
         my $davhost = $self->{services}->{http}->host;
         if (defined $self->{services}->{http}->port) {
@@ -721,7 +725,6 @@ sub _generate_imapd_conf
         event_notifier => 'pusher',
     );
     if ($cyrus_major_version >= 3) {
-        $config->set(imipnotifier => 'imip');
         $config->set_bits('event_groups', 'mailbox message flags calendar');
 
         if ($cyrus_major_version > 3 || $cyrus_minor_version >= 1) {

--- a/cassandane/Cassandane/Instance.pm
+++ b/cassandane/Cassandane/Instance.pm
@@ -681,6 +681,7 @@ sub _build_skeleton
         'data',
         'meta',
         'run',
+        'smtpd',
         'tmp',
     );
     foreach my $sd (@subdirs)
@@ -1120,6 +1121,9 @@ sub _start_smtpd
             port => $port,
             max_servers => 3, # default is 50, yikes
             control_file => "$basedir/conf/smtpd.json",
+            xmtp_tmp_dir => "$basedir/tmp/",
+            store_msg => 1,
+            messages_dir => "$basedir/smtpd/",
         });
         $smtpd->run() or die;
         exit 0; # Never reached

--- a/cassandane/tiny-tests/Caldav/imip_quote_cn
+++ b/cassandane/tiny-tests/Caldav/imip_quote_cn
@@ -1,4 +1,7 @@
 #!perl
+use warnings;
+use strict;
+
 use Cassandane::Tiny;
 use Data::UUID;
 
@@ -15,19 +18,36 @@ sub test_imip_quote_cn
     my $service = $self->{instance}->get_service("http");
     my $caldav  = $self->{caldav};
 
-    my %testCases = (
-        'A'              => 'A',
-        'A <B>'          => '"A <B>"',
-        "A \N{TOMATO} B" => '=?UTF-8?Q?A_=F0=9F=8D=85_B?=',
-        'A "T" B'        => '"A \"T\" B"',
-        'A \ B'          => '"A \\ B"',
-        'A,B'            => '"A,B"',
+    my @testCases = (
+        { mailto => 'a@example.com',
+          cn     => 'A',
+          expect => 'A',
+        },
+        { mailto => 'b@example.com',
+          cn     => 'A <B>',
+          expect => '"A <B>"',
+        },
+        { mailto => 'c@example.com',
+          cn     => "A \N{TOMATO} B",
+          expect => '=?UTF-8?Q?A_=F0=9F=8D=85_B?=',
+        },
+        { mailto => 'd@example.com',
+          cn     => 'A "T" B',
+          expect => '"A \"T\" B"',
+        },
+        { mailto => 'e@example.com',
+          cn     => 'A \ B',
+          expect => '"A \\ B"',
+        },
+        { mailto => 'f@example.com',
+          cn     => 'A,B',
+          expect => '"A,B"',
+        },
     );
 
     my $uuidgen = Data::UUID->new;
 
-    keys %testCases;
-    while (my ($cn, $wantEmailAddressName) = each %testCases) {
+    foreach my $tc (@testCases) {
         my $uid  = $uuidgen->create_str;
         my $ical = <<EOF;
 BEGIN:VCALENDAR
@@ -41,7 +61,7 @@ SUMMARY:test
 DTSTART:20240703T153000Z
 DTSTAMP:20240703T153000Z
 SEQUENCE:0
-ORGANIZER;CN=$cn:MAILTO:mctest\@example.com
+ORGANIZER;CN=$tc->{cn}:MAILTO:$tc->{mailto}
 ATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
 END:VEVENT
 END:VCALENDAR
@@ -50,9 +70,31 @@ EOF
             'PUT', "Default/$uid.ics", $ical,
             'Content-Type' => 'text/calendar; charset=utf-8'
         );
+    }
 
-        # FIXME this is where we would want to validate that the email name
-        # in the To: header that got passed to SMTPServer matches
-        # $wantEmailAddressName.
+    my %recipients = ();
+
+    my $messages_dir = $self->{instance}->get_basedir() . '/smtpd';
+    opendir(my $dh, $messages_dir) or die "opendir $messages_dir: $!";
+    while (readdir $dh) {
+        next if not m/\.smtp$/;
+
+        my $message_file = "$messages_dir/$_";
+        open(my $fh, '<', $message_file) or die "open $message_file: $!";
+        while (<$fh>) {
+            s/[\x0d\x0a]{1,2}$//; # leniently chomp eol chars
+            last if not $_; # empty line: end of headers
+
+            if (m/^To: (.*) <([^>]+)>$/) {
+                $recipients{$2} = $1;
+            }
+        }
+        close $fh;
+    }
+    closedir $dh;
+
+    foreach my $tc (@testCases) {
+        $self->assert_str_equals($tc->{expect},
+                                 $recipients{$tc->{mailto}});
     }
 }

--- a/cassandane/tiny-tests/Caldav/imip_quote_cn
+++ b/cassandane/tiny-tests/Caldav/imip_quote_cn
@@ -3,12 +3,14 @@ use Cassandane::Tiny;
 use Data::UUID;
 
 sub test_imip_quote_cn
-  : needs_component_httpd {
+    :needs_component_httpd
+    :NoStartInstances
+{
     my ($self) = @_;
 
-    # FIXME we need to override the imipnotifier imapd.conf
-    # setting, it's set to 'imip' but we want it to be set
-    # to NULL to trigger the code we are testing here.
+    $self->{instance}->{config}->set('imipnotifier' => undef);
+    $self->_start_instances();
+    $self->_setup_http_service_objects();
 
     my $service = $self->{instance}->get_service("http");
     my $caldav  = $self->{caldav};

--- a/cassandane/tiny-tests/Caldav/imip_quote_cn
+++ b/cassandane/tiny-tests/Caldav/imip_quote_cn
@@ -1,0 +1,56 @@
+#!perl
+use Cassandane::Tiny;
+use Data::UUID;
+
+sub test_imip_quote_cn
+  : needs_component_httpd {
+    my ($self) = @_;
+
+    # FIXME we need to override the imipnotifier imapd.conf
+    # setting, it's set to 'imip' but we want it to be set
+    # to NULL to trigger the code we are testing here.
+
+    my $service = $self->{instance}->get_service("http");
+    my $caldav  = $self->{caldav};
+
+    my %testCases = (
+        'A'              => 'A',
+        'A <B>'          => '"A <B>"',
+        "A \N{TOMATO} B" => '=?UTF-8?Q?A_=F0=9F=8D=85_B?=',
+        'A "T" B'        => '"A \"T\" B"',
+        'A \ B'          => '"A \\ B"',
+        'A,B'            => '"A,B"',
+    );
+
+    my $uuidgen = Data::UUID->new;
+
+    keys %testCases;
+    while (my ($cn, $wantEmailAddressName) = each %testCases) {
+        my $uid  = $uuidgen->create_str;
+        my $ical = <<EOF;
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Foo//Bar//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:$uid
+TRANSP:OPAQUE
+SUMMARY:test
+DTSTART:20240703T153000Z
+DTSTAMP:20240703T153000Z
+SEQUENCE:0
+ORGANIZER;CN=$cn:MAILTO:mctest\@example.com
+ATTENDEE;PARTSTAT=ACCEPTED;RSVP=TRUE:MAILTO:cassandane\@example.com
+END:VEVENT
+END:VCALENDAR
+EOF
+        $caldav->Request(
+            'PUT', "Default/$uid.ics", $ical,
+            'Content-Type' => 'text/calendar; charset=utf-8'
+        );
+
+        # FIXME this is where we would want to validate that the email name
+        # in the To: header that got passed to SMTPServer matches
+        # $wantEmailAddressName.
+    }
+}

--- a/cassandane/tiny-tests/Caldav/imip_quote_cn
+++ b/cassandane/tiny-tests/Caldav/imip_quote_cn
@@ -37,7 +37,7 @@ sub test_imip_quote_cn
         },
         { mailto => 'e@example.com',
           cn     => 'A \ B',
-          expect => '"A \\ B"',
+          expect => '"A \\\\ B"',
         },
         { mailto => 'f@example.com',
           cn     => 'A,B',


### PR DESCRIPTION
Wasn't sure if it was okay to push directly to your fork, so here's a pull request instead...

The new testing infrastructure is in the "Instance: ..." and "SMTPServer: ..." commits.

The "FIXUP ..." commit removes "defaultdomain" from Caldav because it broke a lot of existing Caldav tests, and it doesn't seem to be necessary for these tests (at least, for what we're testing so far).  If you do end up needing defaultdomain for this one particular test, enable it in the test at the same time as it overrides imipnotifier.

The rest of the commits are the steps I took converting your test sketch to a working implementation using the updated infrastructure.

You should probably rebase and reorder so that the two test infrastructure commits are first, then your actual code change and my test commits could potentially be squashed into one commit.  I've left my steps separate for now for clarity, but rearrange however makes sense to you.