### PR TITLE
JMAP Calendars: ignore `null` values in `CalendarEvent/set{create}`

### DIFF
--- a/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
+++ b/cassandane/Cassandane/Cyrus/JMAPCalendars.pm
@@ -116,272 +116,212 @@ sub normalize_event
 {
     my ($event) = @_;
 
-    if (not exists $event->{q{@type}}) {
-        $event->{q{@type}} = 'Event';
+    # @type
+    $event->{q{@type}} //= 'Event';
+    # calendarIds
+    if (not defined $event->{calendarIds}) {
+        delete($event->{calendarIds});
     }
-    if (not exists $event->{freeBusyStatus}) {
-        $event->{freeBusyStatus} = 'busy';
+    # alerts
+    if (not defined $event->{alerts}) {
+        delete($event->{alerts});
     }
-    if (not exists $event->{priority}) {
-        $event->{priority} = 0;
-    }
-    if (not exists $event->{title}) {
-        $event->{title} = '';
-    }
-    if (not exists $event->{description}) {
-        $event->{description} = '';
-    }
-    if (not exists $event->{duration}) {
-        $event->{duration} = 'PT0S';
-    }
-    if (not exists $event->{descriptionContentType}) {
-        $event->{descriptionContentType} = 'text/plain';
-    }
-    if (not exists $event->{showWithoutTime}) {
-        $event->{showWithoutTime} = JSON::false;
-    }
-    if (not exists $event->{locations}) {
-        $event->{locations} = undef;
-    } elsif (defined $event->{locations}) {
-        foreach my $loc (values %{$event->{locations}}) {
-            if (not exists $loc->{name}) {
-                $loc->{name} = '';
-            }
-            if (not exists $loc->{q{@type}}) {
-                $loc->{q{@type}} = 'Location';
-            }
-            foreach my $link (values %{$loc->{links}}) {
-                if (not exists $link->{q{@type}}) {
-                    $link->{q{@type}} = 'Link';
-                }
-            }
-        }
-    }
-    if (not exists $event->{virtualLocations}) {
-        $event->{virtualLocations} = undef;
-    } elsif (defined $event->{virtualLocations}) {
-        foreach my $loc (values %{$event->{virtualLocations}}) {
-            if (not exists $loc->{name}) {
-                $loc->{name} = ''
-            }
-            if (not exists $loc->{description}) {
-                $loc->{description} = undef;
-            }
-            if (not exists $loc->{uri}) {
-                $loc->{uri} = undef;
-            }
-            if (not exists $loc->{q{@type}}) {
-                $loc->{q{@type}} = 'VirtualLocation';
-            }
-        }
-    }
-    if (not exists $event->{keywords}) {
-        $event->{keywords} = undef;
-    }
-    if (not exists $event->{locale}) {
-        $event->{locale} = undef;
-    }
-    if (not exists $event->{links}) {
-        $event->{links} = undef;
-    } elsif (defined $event->{links}) {
-        foreach my $link (values %{$event->{links}}) {
-            if (not exists $link->{q{@type}}) {
-                $link->{q{@type}} = 'Link';
-            }
-        }
-    }
-    if (not exists $event->{relatedTo}) {
-        $event->{relatedTo} = undef;
-    } elsif (defined $event->{relatedTo}) {
-        foreach my $rel (values %{$event->{relatedTo}}) {
-            if (not exists $rel->{q{@type}}) {
-                $rel->{q{@type}} = 'Relation';
-            }
-        }
-    }
-    if (not exists $event->{participants}) {
-        $event->{participants} = undef;
-    } elsif (defined $event->{participants}) {
-        foreach my $p (values %{$event->{participants}}) {
-            if (not exists $p->{linkIds}) {
-                $p->{linkIds} = undef;
-            }
-            if (not exists $p->{participationStatus}) {
-                $p->{participationStatus} = 'needs-action';
-            }
-            if (not exists $p->{expectReply}) {
-                $p->{expectReply} = JSON::false;
-            }
-            if (not exists $p->{scheduleSequence}) {
-                $p->{scheduleSequence} = 0;
-            }
-            if (not exists $p->{q{@type}}) {
-                $p->{q{@type}} = 'Participant';
-            }
-            foreach my $link (values %{$p->{links}}) {
-                if (not exists $link->{q{@type}}) {
-                    $link->{q{@type}} = 'Link';
-                }
-            }
-        }
-    }
-    if (not exists $event->{replyTo}) {
-        $event->{replyTo} = undef;
-    }
-    if (not exists $event->{recurrenceRule}) {
-        $event->{recurrenceRule} = undef;
-    } elsif (defined $event->{recurrenceRule}) {
-        my $rrule = $event->{recurrenceRule};
-        if (not exists $rrule->{interval}) {
-            $rrule->{interval} = 1;
-        }
-        if (not exists $rrule->{firstDayOfWeek}) {
-            $rrule->{firstDayOfWeek} = 'mo';
-        }
-        if (not exists $rrule->{rscale}) {
-            $rrule->{rscale} = 'gregorian';
-        }
-        if (not exists $rrule->{skip}) {
-            $rrule->{skip} = 'omit';
-        }
-        if (not exists $rrule->{byDay}) {
-            $rrule->{byDay} = undef;
-        } elsif (defined $rrule->{byDay}) {
-            foreach my $nday (@{$rrule->{byDay}}) {
-                if (not exists $nday->{q{@type}}) {
-                    $nday->{q{@type}} = 'NDay';
-                }
-            }
-        }
-        if (not exists $rrule->{q{@type}}) {
-            $rrule->{q{@type}} = 'RecurrenceRule';
-        }
-    }
-    if (not exists $event->{excludedRecurrenceRules}) {
-        $event->{excludedRecurrenceRules} = undef;
-    } elsif (defined $event->{excludedRecurrenceRules}) {
-        foreach my $exrule (@{$event->{excludedRecurrenceRules}}) {
-            if (not exists $exrule->{interval}) {
-                $exrule->{interval} = 1;
-            }
-            if (not exists $exrule->{firstDayOfWeek}) {
-                $exrule->{firstDayOfWeek} = 'mo';
-            }
-            if (not exists $exrule->{rscale}) {
-                $exrule->{rscale} = 'gregorian';
-            }
-            if (not exists $exrule->{skip}) {
-                $exrule->{skip} = 'omit';
-            }
-            if (not exists $exrule->{byDay}) {
-                $exrule->{byDay} = undef;
-            } elsif (defined $exrule->{byDay}) {
-                foreach my $nday (@{$exrule->{byDay}}) {
-                    if (not exists $nday->{q{@type}}) {
-                        $nday->{q{@type}} = 'NDay';
-                    }
-                }
-            }
-            if (not exists $exrule->{q{@type}}) {
-                $exrule->{q{@type}} = 'RecurrenceRule';
-            }
-        }
-    }
-    if (not exists $event->{recurrenceOverrides}) {
-        $event->{recurrenceOverrides} = undef;
-    }
-    if (not exists $event->{alerts}) {
-        $event->{alerts} = undef;
-    }
-    elsif (defined $event->{alerts}) {
+    else {
         foreach my $alert (values %{$event->{alerts}}) {
-            if (not exists $alert->{action}) {
-                $alert->{action} = 'display';
-            }
-            if (not exists $alert->{q{@type}}) {
-                $alert->{q{@type}} = 'Alert';
-            }
-            if (not exists $alert->{relatedTo}) {
-                $alert->{relatedTo} = undef;
-            } elsif (defined $alert->{relatedTo}) {
+            $alert->{action} //= 'display';
+            $alert->{q{@type}} //= 'Alert';
+            if (not defined $alert->{relatedTo}) {
+                delete($alert->{relatedTo});
+            } else {
                 foreach my $rel (values %{$alert->{relatedTo}}) {
-                    if (not exists $rel->{q{@type}}) {
-                        $rel->{q{@type}} = 'Relation';
-                    }
-                    if (not exists $rel->{relation}) {
-                        $rel->{relation} = {};
-                    }
+                    $rel->{q{@type}} //= 'Relation';
+                    $rel->{relation} //= {};
                 }
             }
-            if ($alert->{trigger} and $alert->{trigger}{q{@type}} eq 'OffsetTrigger') {
-                if (not exists $alert->{trigger}{relativeTo}) {
+            if (defined $alert->{trigger}) {
+                $alert->{trigger}{q{@type}} //= 'OffsetTrigger';
+                if ((not defined $alert->{trigger}{relativeTo}) &&
+                    $alert->{trigger}{q{@type}} eq 'OffsetTrigger') {
                     $alert->{trigger}{relativeTo} = 'start';
                 }
             }
         }
     }
-    if (not exists $event->{useDefaultAlerts}) {
-        $event->{useDefaultAlerts} = JSON::false;
+    # categories
+    if (not defined $event->{categories}) {
+        delete($event->{categories});
     }
-    if (not exists $event->{prodId}) {
-        $event->{prodId} = undef;
+    # color
+    if (not defined $event->{color}) {
+        delete($event->{color});
     }
-    if (not exists $event->{links}) {
-        $event->{links} = undef;
-    } elsif (defined $event->{links}) {
+    # description
+    $event->{description} //= '';
+    # descriptionContentType
+    $event->{descriptionContentType} //= 'text/plain';
+    # duration
+    $event->{duration} //= 'PT0S';
+    # endTimeZone
+    if (not defined $event->{endTimeZone}) {
+        delete($event->{endTimeZone});
+    }
+    # freeBusyStatus
+    $event->{freeBusyStatus} //= 'busy';
+    # keywords
+    if (not defined $event->{keywords}) {
+        delete($event->{keywords});
+    }
+    # isDraft
+    $event->{isDraft} //= JSON::false;
+    # links
+    if (not defined $event->{links}) {
+        delete($event->{links});
+    } else {
         foreach my $link (values %{$event->{links}}) {
-            if (not exists $link->{cid}) {
-                $link->{cid} = undef;
+            if (not defined $link->{cid}) {
+                delete($link->{cid});
             }
-            if (not exists $link->{contentType}) {
-                $link->{contentType} = undef;
+            if (not defined $link->{contentType}) {
+                delete($link->{contentType});
             }
-            if (not exists $link->{size}) {
-                $link->{size} = undef;
+            if (not defined $link->{size}) {
+                delete($link->{size});
             }
-            if (not exists $link->{title}) {
-                $link->{title} = undef;
+            if (not defined $link->{title}) {
+                delete($link->{title});
             }
-            if (not exists $link->{q{@type}}) {
-                $link->{q{@type}} = 'Link';
+            $link->{q{@type}} //= 'Link';
+        }
+    }
+    # locale
+    if (not defined $event->{locale}) {
+        delete($event->{locale});
+    }
+    # locations
+    if (not defined $event->{locations}) {
+        delete($event->{locations});
+    } else {
+        foreach my $loc (values %{$event->{locations}}) {
+            $loc->{q{@type}} //= 'Location';
+            foreach my $link (values %{$loc->{links}}) {
+                $link->{q{@type}} //= 'Link';
             }
         }
     }
-    if (not exists $event->{status}) {
-        $event->{status} = "confirmed";
+    # mainLocationId
+    if (not defined $event->{mainLocationId}) {
+        delete($event->{mainLocationId});
     }
-    if (not exists $event->{privacy}) {
-        $event->{privacy} = "public";
+    # method
+    if (not defined $event->{method}) {
+        delete($event->{method});
     }
-    if (not exists $event->{isDraft}) {
-        $event->{isDraft} = JSON::false;
+    # organizerCalendarAddress
+    if (not defined $event->{organizerCalendarAddress}) {
+        delete($event->{organizerCalendarAddress});
     }
-    if (not exists $event->{excluded}) {
-        $event->{excluded} = JSON::false,
+    # participants
+    if (not defined $event->{participants}) {
+        delete($event->{participants});
+    } else {
+        foreach my $p (values %{$event->{participants}}) {
+            if (not defined $p->{linkIds}) {
+                delete($p->{linkIds});
+            }
+            $p->{participationStatus} //= 'needs-action';
+            $p->{expectReply} //= JSON::false;
+            $p->{scheduleSequence} //= 0;
+            $p->{q{@type}} //= 'Participant';
+            foreach my $link (values %{$p->{links}}) {
+                $link->{q{@type}} //= 'Link';
+            }
+        }
+    }
+    # priority
+    $event->{priority} //= 0;
+    # privacy
+    $event->{privacy} //= "public";
+    # recurrenceId
+    if (not defined $event->{recurrenceId}) {
+        delete($event->{recurrenceId});
+    }
+    # recurrenceIdTimeZone
+    if (not defined $event->{recurrenceIdTimeZone}) {
+        delete($event->{recurrenceIdTimeZone});
+    }
+    # recurrenceRule
+    if (not defined $event->{recurrenceRule}) {
+        delete($event->{recurrenceRule});
+    } else {
+        my $rrule = $event->{recurrenceRule};
+        $rrule->{interval} //= 1;
+        $rrule->{firstDayOfWeek} //= 'mo';
+        $rrule->{rscale} //= 'gregorian';
+        $rrule->{skip} //= 'omit';
+        if (not defined $rrule->{byDay}) {
+            delete($rrule->{byDay});
+        } else {
+            foreach my $nday (@{$rrule->{byDay}}) {
+                $nday->{q{@type}} //= 'NDay';
+            }
+        }
+        $rrule->{q{@type}} //= 'RecurrenceRule';
+    }
+    # recurrenceOverrides
+    if (not defined $event->{recurrenceOverrides}) {
+        delete($event->{recurrenceOverrides});
+    }
+    # relatedTo
+    if (not defined $event->{relatedTo}) {
+        delete($event->{relatedTo});
+    } else {
+        foreach my $rel (values %{$event->{relatedTo}}) {
+            $rel->{q{@type}} //= 'Relation';
+        }
+    }
+    # sentBy
+    if (not defined $event->{sentBy}) {
+        delete($event->{sentBy});
+    }
+    # showWithoutTime
+    $event->{showWithoutTime} //= JSON::false;
+    # status
+    $event->{status} //= "confirmed";
+    # title
+    $event->{title} //= '';
+    # timeZone
+    if (not defined $event->{timeZone}) {
+        delete($event->{timeZone});
+    }
+    # useDefaultAlerts
+    $event->{useDefaultAlerts} //= JSON::false;
+    # virtualLocations
+    if (not defined $event->{virtualLocations}) {
+        delete($event->{virtualLocations});
+    } else {
+        foreach my $loc (values %{$event->{virtualLocations}}) {
+            $loc->{name} //= '';
+            if (not defined $loc->{description}) {
+                delete($loc->{description});
+            }
+            if (not defined $loc->{uri}) {
+                delete($loc->{uri});
+            }
+            $loc->{q{@type}} //= 'VirtualLocation';
+        }
     }
 
-    if (not exists $event->{calendarIds}) {
-        $event->{calendarIds} = undef;
-    }
-    if (not exists $event->{timeZone}) {
-        $event->{timeZone} = undef;
-    }
-
-    if (not exists $event->{mayInviteSelf}) {
-        $event->{mayInviteSelf} = JSON::false,
-    }
-
-    # undefine dynamically generated values
-    $event->{created} = undef;
-    $event->{updated} = undef;
-    $event->{uid} = undef;
-    $event->{id} = undef;
-    $event->{"x-href"} = undef;
-    $event->{sequence} = 0;
-    $event->{prodId} = undef;
-    $event->{isOrigin} = undef;
+    # delete dynamically generated values
+    delete($event->{created});
+    delete($event->{updated});
+    delete($event->{uid});
+    delete($event->{id});
+    delete($event->{"x-href"});
+    delete($event->{prodId});
+    delete($event->{isOrigin});
     delete($event->{blobId});
     delete($event->{debugBlobId});
+    $event->{sequence} = 0;
 }
 
 sub assert_normalized_event_equals
@@ -397,7 +337,7 @@ sub assert_normalized_event_equals
 
     normalize_event($copyA);
     normalize_event($copyB);
-    return $self->assert_deep_equals($copyA, $copyB);
+    return $self->assert_cmp_deeply($copyA, $copyB);
 }
 
 sub putandget_vevent

--- a/cassandane/tiny-tests/Caldav/calendar_create_badname
+++ b/cassandane/tiny-tests/Caldav/calendar_create_badname
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_create_badname ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Starts with 'C' and <= 12 chars long
+    my $res = $CalDAV->SafeRequest('MKCALENDAR', 'C0123456789A');
+    $self->assert_num_equals(403, $res->{http_response}{status});
+
+    # Starts with 'c' and <= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCOL', 'c01234567890A');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+
+    # Starts with 'C' and >= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCALENDAR', 'C01234567890AB');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_null_values
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_null_values
@@ -1,0 +1,71 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendarevent_set_create_null_values
+    ($self)
+{
+    my $jmap = $self->default_user->jmap;
+    my $calid = $self->default_user->calendars->default->id;
+
+    # Assert that null values for top-level properties in
+    # CalendarEvent/set{create} are ignored, not rejected.
+
+    my $event_all_optional_null = {
+        # Mandatory properties
+        calendarIds => { $calid => JSON::true },
+        start => '2026-01-02T03:04:05',
+        # Optional properties
+        alerts => undef,
+        categories => undef,
+        color => undef,
+        created => undef,
+        description => undef,
+        descriptionContentType => undef,
+        duration => undef,
+        endTimeZone => undef,
+        freeBusyStatus => undef,
+        keywords => undef,
+        links => undef,
+        locale => undef,
+        locations => undef,
+        mainLocationId => undef,
+        method => undef,
+        organizerCalendarAddress => undef,
+        participants => undef,
+        priority => undef,
+        privacy => undef,
+        prodId => undef,
+        recurrenceId => undef,
+        recurrenceIdTimeZone => undef,
+        recurrenceOverrides => undef,
+        recurrenceRule => undef,
+        relatedTo => undef,
+        sentBy => undef,
+        sequence => undef,
+        showWithoutTime => undef,
+        status => undef,
+        timeZone => undef,
+        title => undef,
+        uid => undef,
+        updated => undef,
+        version => undef,
+        virtualLocations => undef,
+    };
+
+    my @props = keys %$event_all_optional_null;
+
+    my $res = $jmap->request([
+        [ "CalendarEvent/set" => {
+            create => {
+                1 => $event_all_optional_null,
+            },
+        }, "a", ],
+        [ "CalendarEvent/get" => {
+            ids => [ '#1' ],
+            properties => \@props,
+        }, "b", ],
+    ]);
+
+    my $got_event = $res->sentence_named('CalendarEvent/get')->arguments->{list}[0];
+    $self->assert_normalized_event_equals($event_all_optional_null, $got_event);
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -103,6 +103,7 @@ struct partial_caldata_t {
 static int meth_options_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_fb(struct transaction_t *txn, void *params);
+static int meth_mkcalendar(struct transaction_t *txn, void *params);
 
 static void my_caldav_init(struct buf *serverinfo);
 static int my_caldav_auth(const char *userid);
@@ -618,8 +619,8 @@ struct namespace_t namespace_calendar = {
         { &meth_get_head_cal,   &caldav_params },       /* GET          */
         { &meth_get_head_cal,   &caldav_params },       /* HEAD         */
         { &meth_lock,           &caldav_params },       /* LOCK         */
-        { &meth_mkcol,          &caldav_params },       /* MKCALENDAR   */
-        { &meth_mkcol,          &caldav_params },       /* MKCOL        */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCALENDAR   */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
         { &meth_patch,          &caldav_params },       /* PATCH        */
@@ -2689,6 +2690,48 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     /* Unknown action */
     return HTTP_NO_CONTENT;
+}
+
+static int meth_mkcalendar(struct transaction_t *txn, void *params)
+{
+    int r = 0;
+
+    /* Parse the path (use our own entry to suppress lookup) */
+    txn->req_tgt.mbentry = mboxlist_entry_create();
+    r = caldav_parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+
+    /* Make sure method is allowed (only allowed on child of home-set) */
+    if (!txn->req_tgt.collection || txn->req_tgt.resource ||
+        (txn->req_tgt.collection[0] == 'C' &&
+         txn->req_tgt.collen <= CONV_JMAPID_SIZE + 1)) {
+        txn->error.precond = CALDAV_LOCATION_OK;
+        return HTTP_FORBIDDEN;
+    }
+    else if (r) {
+        switch (r) {
+        case IMAP_MAILBOX_EXISTS:
+            txn->error.precond = DAV_RES_EXISTS;
+            break;
+                
+        case IMAP_PERMISSION_DENIED:
+            txn->error.precond = DAV_NEED_PRIVS;
+            txn->error.rights = DACL_BIND;
+            buf_reset(&txn->buf);
+            buf_printf(&txn->buf, "%s/%s/%s",
+                       txn->req_tgt.namespace->prefix, USER_COLLECTION_PREFIX,
+                       txn->req_tgt.userid);
+            txn->error.resource = buf_cstring(&txn->buf);
+            break;
+                
+        default:
+            txn->error.precond = CALDAV_LOCATION_OK;
+            break;
+        }
+
+        return HTTP_FORBIDDEN;
+    }
+
+    return meth_mkcol(txn, params);
 }
 
 /* Perform post-create MKCOL/MKCALENDAR processing */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5709,9 +5709,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
     /* Response should not be cached */
     txn->flags.cc |= CC_NOCACHE;
 
-    /* Parse the path (use our own entry to suppress lookup) */
-    txn->req_tgt.mbentry = mboxlist_entry_create();
-    r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    if (!txn->req_tgt.mbentry) {
+        /* Parse the path (use our own entry to suppress lookup) */
+        txn->req_tgt.mbentry = mboxlist_entry_create();
+        r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    }
 
     /* Make sure method is allowed (only allowed on child of home-set) */
     if (!txn->req_tgt.collection || txn->req_tgt.resource) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -700,6 +700,14 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
         free(xhref);
     }
 
+    if (jmap_wantprop(rock->get->props, "x-compactId")) {
+        struct conversations_state cstate =
+            { .version = 2, .compact_emailids = 1 }; // force compactId
+        char compactid[JMAP_MAX_CALENDARID_SIZE];
+        jmap_set_calendarid(&cstate, mbentry, compactid);
+        json_object_set_new(obj, "x-compactId", json_string(compactid));
+    }
+    
     if (jmap_wantprop(rock->get->props, "name")) {
         buf_reset(&attrib);
         static const char *displayname_annot =

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -4564,6 +4564,18 @@ static int createevent_toical(jmap_req_t *req,
     jmapctx->jsevent_is_origin_cb = jsevent_is_origin;
     jmapctx->to_ical.serverset = create->serverset;
 
+    if (jmap_is_using(req, JMAP_JSCALENDARBIS_EXTENSION)) {
+        /* Remove any top-level property with value 'null' from the object. */
+        const char *propname;
+        json_t *jval;
+        void *tmp;
+        json_object_foreach_safe(create->jsevent, tmp, propname, jval) {
+            if (json_is_null(jval)) {
+                json_object_del(create->jsevent, propname);
+            }
+        }
+    }
+
     // Set @type property if not already set.
     if (!json_object_get(create->jsevent, "@type")) {
         json_object_set_new(create->jsevent, "@type", json_string("Event"));

--- a/imap/jmap_calendar_props.gperf
+++ b/imap/jmap_calendar_props.gperf
@@ -52,6 +52,7 @@ jmap_property_t;
 "calDavUrl",        JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "mailboxUniqueId",  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 "x-href",           JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
+"x-compactId",      JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 %%
 
 const jmap_prop_hash_table_t jmap_calendar_props_map = {

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -3687,29 +3687,20 @@ static void validate_alerts(jscal_ctx_t *ctx,
                 if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
             }
             else if (!strcmp("relatedTo", key)) {
-                if (!json_is_null(jval)) {
-                    jmap_parser_push(parser, key);
-                    validate_relatedto(ctx, parser, jval);
-                    jmap_parser_pop(parser);
-                }
+                jmap_parser_push(parser, key);
+                validate_relatedto(ctx, parser, jval);
+                jmap_parser_pop(parser);
             }
             else if (!strcmp("trigger", key)) {
-                if (!json_is_null(jval)) {
-                    jmap_parser_push(parser, key);
-                    validate_trigger(ctx, parser, jval);
-                    jmap_parser_pop(parser);
-                }
-                else {
-                    jmap_parser_invalid(parser, key);
-                }
+                jmap_parser_push(parser, key);
+                validate_trigger(ctx, parser, jval);
+                jmap_parser_pop(parser);
             }
             // Extension properties
             else if (!strcmp("iCalendar", key)) {
-                if (!json_is_null(jval)) {
-                    jmap_parser_push(parser, key);
-                    validate_jicalcomponent(ctx, parser, jval);
-                    jmap_parser_pop(parser);
-                }
+                jmap_parser_push(parser, key);
+                validate_jicalcomponent(ctx, parser, jval);
+                jmap_parser_pop(parser);
             }
             else if (!is_vendorext_key(key)) {
                 jmap_parser_invalid(parser, key);
@@ -3821,11 +3812,9 @@ static void validate_locations(jscal_ctx_t *ctx,
                 if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
             }
             else if (!strcmp("links", key)) {
-                if (!json_is_null(jval)) {
-                    jmap_parser_push(parser, key);
-                    validate_links(ctx, parser, jval);
-                    jmap_parser_pop(parser);
-                }
+                jmap_parser_push(parser, key);
+                validate_links(ctx, parser, jval);
+                jmap_parser_pop(parser);
             }
             else if (!strcmp("locationTypes", key)) {
                 if (!is_stringset(jval, NULL)) jmap_parser_invalid(parser, key);
@@ -3901,11 +3890,9 @@ static void validate_participants(jscal_ctx_t *ctx,
                 if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
             }
             else if (!strcmp("links", key)) {
-                if (!json_is_null(jval)) {
-                    jmap_parser_push(parser, key);
-                    validate_links(ctx, parser, jval);
-                    jmap_parser_pop(parser);
-                }
+                jmap_parser_push(parser, key);
+                validate_links(ctx, parser, jval);
+                jmap_parser_pop(parser);
             }
             else if (!strcmp("memberOf", key)) {
                 if (!is_stringset(jval, NULL)) jmap_parser_invalid(parser, key);
@@ -4105,16 +4092,16 @@ static void validate_recurrencerule(jscal_ctx_t *ctx,
                 }
                 if (i < json_array_size(jval)) jmap_parser_invalid(parser, key);
             }
-            else if (!json_is_null(jval)) {
+            else {
                 jmap_parser_invalid(parser, key);
             }
         }
         else if (!strcmp("byHour", key)) {
-            if (!json_is_null(jval) && !is_intarray(jval, 0, 23))
+            if (!is_intarray(jval, 0, 23))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("byMinute", key)) {
-            if (!json_is_null(jval) && !is_intarray(jval, 0, 59))
+            if (!is_intarray(jval, 0, 59))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("byMonth", key)) {
@@ -4133,32 +4120,28 @@ static void validate_recurrencerule(jscal_ctx_t *ctx,
                 }
                 if (i < json_array_size(jval)) jmap_parser_invalid(parser, key);
             }
-            else if (!json_is_null(jval)) {
+            else {
                 jmap_parser_invalid(parser, key);
             }
         }
         else if (!strcmp("byMonthDay", key)) {
-            if (!json_is_null(jval)
-                && !is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
+            if (!is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("byWeekNo", key)) {
-            if (!json_is_null(jval)
-                && !is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
+            if (!is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("bySecond", key)) {
-            if (!json_is_null(jval) && !is_intarray(jval, 0, 60))
+            if (!is_intarray(jval, 0, 60))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("bySetPosition", key)) {
-            if (!json_is_null(jval)
-                && !is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
+            if (!is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("byYearDay", key)) {
-            if (!json_is_null(jval)
-                && !is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
+            if (!is_intarray(jval, JMAP_INT_MIN, JMAP_INT_MAX))
                 jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("count", key)) {
@@ -4368,11 +4351,9 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("alerts", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_alerts(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_alerts(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("categories", key)) {
             if (!is_stringset(jval, NULL)) jmap_parser_invalid(parser, key);
@@ -4416,21 +4397,17 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!is_stringset(jval, NULL)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("links", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_links(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_links(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("locale", key)) {
             if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("locations", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_locations(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_locations(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("mainLocationId", key)) {
             const char *s = json_string_value(jval);
@@ -4449,11 +4426,9 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("participants", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_participants(ctx, parser, entry_type, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_participants(ctx, parser, entry_type, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("percentComplete", key)) {
             json_int_t v = json_integer_value(jval);
@@ -4482,25 +4457,19 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!is_timezone(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("recurrenceOverrides", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_recurrenceoverrides(ctx, parser, jentry, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_recurrenceoverrides(ctx, parser, jentry, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("recurrenceRule", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_recurrencerule(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_recurrencerule(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("relatedTo", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_relatedto(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_relatedto(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("sentBy", key)) {
             if (!json_is_string(jval)) jmap_parser_invalid(parser, key);
@@ -4537,19 +4506,15 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!is_supported_version(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("virtualLocations", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_virtuallocations(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_virtuallocations(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         // Extension properties
         else if (!strcmp("iCalendar", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_jicalcomponent(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_jicalcomponent(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         // JMAP Calendar properties
         else if (!strcmp("baseEventId", key) ||
@@ -4688,11 +4653,9 @@ static void validate_group(jscal_ctx_t *ctx,
             if (!is_stringset(jval, NULL)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("links", key)) {
-            if (!json_is_null(jval)) {
-                jmap_parser_push(parser, key);
-                validate_links(ctx, parser, jval);
-                jmap_parser_pop(parser);
-            }
+            jmap_parser_push(parser, key);
+            validate_links(ctx, parser, jval);
+            jmap_parser_pop(parser);
         }
         else if (!strcmp("locale", key)) {
             if (!json_is_string(jval)) jmap_parser_invalid(parser, key);


### PR DESCRIPTION
This updates the `JMAP CalendarEvent/set{create}` implementation to strip any top-level properties with `null` value from the CalendarEvent argument. This is in line with the upcoming draft version of JMAP Calendars which states:

> The client may send a null value for any optional JSCalendar Event property on create. This MUST be treated the same as omitting the property from the JSCalendar Event object. Note, this only applies to top-level properties of the CalendarEvent object.

Along with the changes for `CalendarEvent/set{create}`, this PR also makes handling `null` values in jscalendarbis more strict. The upcoming jscalendarbis specification draft will forbid the `null` value for any JSCalendar property (before, they were allowed for the timeZone and recurrenceIdTimeZone properties).

Likewise, this PR also refactors the Cassandane-internal function to normalize CalendarEvent objects. Where before it set `null` values as default for missing properties, it now deletes properties having `null` values. While updating that test code, it also adds support for a few newly introduced JSCalendar properties that were not handled during normalization.