### PR TITLE
jmap_ical.c: read object identifiers using JSID parameter

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_create_badname
+++ b/cassandane/tiny-tests/Caldav/calendar_create_badname
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_create_badname ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Starts with 'C' and <= 12 chars long
+    my $res = $CalDAV->SafeRequest('MKCALENDAR', 'C0123456789A');
+    $self->assert_num_equals(403, $res->{http_response}{status});
+
+    # Starts with 'c' and <= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCOL', 'c01234567890A');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+
+    # Starts with 'C' and >= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCALENDAR', 'C01234567890AB');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_patch
@@ -1,0 +1,125 @@
+#!perl
+use Cassandane::Tiny;
+use Cassandane::Cyrus::JMAPCalendarsRFC8984;
+
+# Create a CalendarEvent, then reply to it via CalendarEvent/participantReply.
+# Verify that independently of replying with or without the jscalendarbis
+# capability, the mboxevent always includes a patch for the old-style RFC8984
+# participant identifiers.
+
+sub get_imip_notification
+{
+    my ($self) = @_;
+    my $data = $self->{instance}->getnotify();
+    my ($imip) = grep { $_->{METHOD} eq 'imip' } @$data;
+    $self->assert_not_null($imip);
+    return decode_json($imip->{MESSAGE});
+}
+
+sub assert_calendarevent_participantreply_patch
+    ($self, %params)
+{
+    my $reply_jscalbis  = $params{reply_jscalbis};
+
+    my $jmap = $self->default_user->jmap;
+    my $default_cal_id = $self->default_user->calendars->default->id;
+
+    my $jscalbis_capability = 'https://cyrusimap.org/ns/jmap/jscalendarbis';
+
+    my @using = (
+        'urn:ietf:params:jmap:core',
+        'urn:ietf:params:jmap:calendars',
+        'urn:ietf:params:jmap:principals',
+        'urn:ietf:params:jmap:calendars:preferences',
+        'https://cyrusimap.org/ns/jmap/calendars',
+        'https://cyrusimap.org/ns/jmap/debug',
+    );
+
+    my $event = {
+        title => "test",
+        freeBusyStatus => "busy",
+        showWithoutTime => JSON::false,
+        start => "2022-11-23T16:45:00",
+        timeZone => "Australia/Melbourne",
+        duration => "PT1H",
+        replyTo => { imip => 'mailto:cassandane@example.com' },
+        participants => {
+            org => {
+                name => "Cassandane",
+                roles => {
+                    'owner' => JSON::true,
+                },
+                sendTo => {
+                    imip => 'mailto:cassandane@example.com',
+                },
+            },
+            att1 => {
+                name => "Bugs Bunny",
+                roles => {
+                    'attendee' => JSON::true,
+                },
+                sendTo => {
+                    imip => 'mailto:bugs%2Bcarrot@looneytunes.com',
+                },
+            },
+        },
+    };
+
+    xlog $self, "Create event without jscalendarbis capability";
+
+    $jmap->default_using([ @using ]);
+
+    # Clean notifications
+    $self->{instance}->getnotify();
+
+    my $res = $jmap->request([
+        ['CalendarEvent/set', { create => {
+            1 => {
+                %$event, calendarIds => { $default_cal_id => JSON::true }
+            },
+        }}, "R1"]
+    ]);
+    my $event_id = "" . $res->single_sentence->as_set->created_id('1');
+
+    xlog $self, "Assert CalendarEvent/set imip patch";
+    my $payload = $self->get_imip_notification();
+    $self->assert_str_equals("REQUEST", $payload->{method});
+    $self->Cassandane::Cyrus::JMAPCalendarsRFC8984::assert_normalized_event_equals($event, $payload->{patch});
+
+    xlog $self, "Call /participantReply " .
+        ($reply_jscalbis ? "with" : "without") . " jscalendarbis capability";
+
+    $jmap->default_using([ @using, ($reply_jscalbis ? ($jscalbis_capability) : ()) ]);
+
+    # Clean notifications
+    $self->{instance}->getnotify();
+
+    $res = $jmap->request([
+        ['CalendarEvent/participantReply', {
+            eventId => $event_id,
+            participantEmail => 'bugs%2Bcarrot@looneytunes.com',
+            updates => { participationStatus => "accepted" }
+        }, "R1"]
+    ]);
+
+    xlog $self, "Assert participantReply imip patch";
+    $payload = $self->get_imip_notification();
+    $self->assert_str_equals("REQUEST", $payload->{method});
+    $self->assert_cmp_deeply({
+        'participants/att1/participationStatus' => 'accepted',
+        'participants/att1/scheduleForceSend' => JSON::true,
+        'participants/org/scheduleStatus' => [ '1.2' ],
+    }, $payload->{patch});
+}
+
+sub test_calendarevent_participantreply_patch_rfc8984_jscalbis
+    ($self)
+{
+    $self->assert_calendarevent_participantreply_patch(reply_jscalbis => 1);
+}
+
+sub test_calendarevent_participantreply_patch_rfc8984_rfc8984
+    ($self)
+{
+    $self->assert_calendarevent_participantreply_patch(reply_jscalbis => 0);
+}

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -103,6 +103,7 @@ struct partial_caldata_t {
 static int meth_options_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_fb(struct transaction_t *txn, void *params);
+static int meth_mkcalendar(struct transaction_t *txn, void *params);
 
 static void my_caldav_init(struct buf *serverinfo);
 static int my_caldav_auth(const char *userid);
@@ -618,8 +619,8 @@ struct namespace_t namespace_calendar = {
         { &meth_get_head_cal,   &caldav_params },       /* GET          */
         { &meth_get_head_cal,   &caldav_params },       /* HEAD         */
         { &meth_lock,           &caldav_params },       /* LOCK         */
-        { &meth_mkcol,          &caldav_params },       /* MKCALENDAR   */
-        { &meth_mkcol,          &caldav_params },       /* MKCOL        */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCALENDAR   */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
         { &meth_patch,          &caldav_params },       /* PATCH        */
@@ -2689,6 +2690,48 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     /* Unknown action */
     return HTTP_NO_CONTENT;
+}
+
+static int meth_mkcalendar(struct transaction_t *txn, void *params)
+{
+    int r = 0;
+
+    /* Parse the path (use our own entry to suppress lookup) */
+    txn->req_tgt.mbentry = mboxlist_entry_create();
+    r = caldav_parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+
+    /* Make sure method is allowed (only allowed on child of home-set) */
+    if (!txn->req_tgt.collection || txn->req_tgt.resource ||
+        (txn->req_tgt.collection[0] == 'C' &&
+         txn->req_tgt.collen <= CONV_JMAPID_SIZE + 1)) {
+        txn->error.precond = CALDAV_LOCATION_OK;
+        return HTTP_FORBIDDEN;
+    }
+    else if (r) {
+        switch (r) {
+        case IMAP_MAILBOX_EXISTS:
+            txn->error.precond = DAV_RES_EXISTS;
+            break;
+                
+        case IMAP_PERMISSION_DENIED:
+            txn->error.precond = DAV_NEED_PRIVS;
+            txn->error.rights = DACL_BIND;
+            buf_reset(&txn->buf);
+            buf_printf(&txn->buf, "%s/%s/%s",
+                       txn->req_tgt.namespace->prefix, USER_COLLECTION_PREFIX,
+                       txn->req_tgt.userid);
+            txn->error.resource = buf_cstring(&txn->buf);
+            break;
+                
+        default:
+            txn->error.precond = CALDAV_LOCATION_OK;
+            break;
+        }
+
+        return HTTP_FORBIDDEN;
+    }
+
+    return meth_mkcol(txn, params);
 }
 
 /* Perform post-create MKCOL/MKCALENDAR processing */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5709,9 +5709,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
     /* Response should not be cached */
     txn->flags.cc |= CC_NOCACHE;
 
-    /* Parse the path (use our own entry to suppress lookup) */
-    txn->req_tgt.mbentry = mboxlist_entry_create();
-    r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    if (!txn->req_tgt.mbentry) {
+        /* Parse the path (use our own entry to suppress lookup) */
+        txn->req_tgt.mbentry = mboxlist_entry_create();
+        r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    }
 
     /* Make sure method is allowed (only allowed on child of home-set) */
     if (!txn->req_tgt.collection || txn->req_tgt.resource) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -700,6 +700,14 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
         free(xhref);
     }
 
+    if (jmap_wantprop(rock->get->props, "x-compactId")) {
+        struct conversations_state cstate =
+            { .version = 2, .compact_emailids = 1 }; // force compactId
+        char compactid[JMAP_MAX_CALENDARID_SIZE];
+        jmap_set_calendarid(&cstate, mbentry, compactid);
+        json_object_set_new(obj, "x-compactId", json_string(compactid));
+    }
+    
     if (jmap_wantprop(rock->get->props, "name")) {
         buf_reset(&attrib);
         static const char *displayname_annot =

--- a/imap/jmap_calendar_props.gperf
+++ b/imap/jmap_calendar_props.gperf
@@ -52,6 +52,7 @@ jmap_property_t;
 "calDavUrl",        JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "mailboxUniqueId",  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 "x-href",           JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
+"x-compactId",      JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 %%
 
 const jmap_prop_hash_table_t jmap_calendar_props_map = {

--- a/imap/jmap_ical.c
+++ b/imap/jmap_ical.c
@@ -776,10 +776,20 @@ static void remove_xjmapid(icalcomponent *comp)
     }
 }
 
+/* Look up the JSCalendar id of an iCalendar property. The jscalendarbis
+ * implementation in jscalendar.c sets the JSI" parameter, so prefer that
+ * and fall back to the X-JMAP-ID parameter for backwards compatibility. */
+static const char *icalproperty_get_jsid(icalproperty *prop)
+{
+    const char *id = icalproperty_get_xparam_value(prop, "JSID");
+    if (!id) id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+    return id;
+}
+
 static void xjmapid_from_icalm(struct buf *dst, icalproperty *prop)
 {
     buf_reset(dst);
-    const char *id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+    const char *id = icalproperty_get_jsid(prop);
     char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
     if (!id) {
         id = sha1hexstr(icalproperty_as_ical_string(prop), keybuf);
@@ -799,7 +809,7 @@ static char *xjmapid_from_ical(icalproperty *prop)
 EXPORTED const char *jmap_partid_from_ical(icalproperty *prop)
 {
     static char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
-    const char *id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+    const char *id = icalproperty_get_jsid(prop);
 
     if (!id) {
         char *uri = normalized_uri(icalproperty_get_value_as_string(prop));
@@ -836,7 +846,7 @@ static icalproperty* findprop_byid(icalcomponent *comp, const char *id,
          prop;
          prop = icalcomponent_get_next_property(comp, kind)) {
 
-        const char *oldid = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+        const char *oldid = icalproperty_get_jsid(prop);
         char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
         if (!oldid)
             oldid = sha1hexstr(icalproperty_get_value_as_string(prop), keybuf);
@@ -2316,7 +2326,7 @@ static json_t* linksbyprop_from_ical(icalcomponent *comp,
                 }
             }
 
-            const char *id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+            const char *id = icalproperty_get_jsid(prop);
             char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
             if (!id)
                 id = sha1hexstr(icalproperty_get_value_as_string(prop), keybuf);
@@ -2712,7 +2722,7 @@ participants_from_ical(icalcomponent *comp, json_t *linksbyparticipant)
         hash_insert(uri, prop, &attendee_by_uri);
 
         /* Map mailto:URI to ID */
-        const char *id = icalproperty_get_xparam_value(prop, JMAPICAL_XPARAM_ID);
+        const char *id = icalproperty_get_jsid(prop);
         char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
         if (!id) id = sha1hexstr(uri, keybuf);
         hash_insert(uri, xstrdup(id), &id_by_uri);
@@ -2782,7 +2792,7 @@ participants_from_ical(icalcomponent *comp, json_t *linksbyparticipant)
         if (uri) {
             if (!hash_lookup(uri, &attendee_by_uri)) {
                 /* Add a default participant for the organizer. */
-                const char *id = icalproperty_get_xparam_value(orga, JMAPICAL_XPARAM_ID);
+                const char *id = icalproperty_get_jsid(orga);
                 char keybuf[JMAPICAL_SHA1HEXSTR_LEN];
                 if (!id) id = sha1hexstr(uri, keybuf);
                 json_t *p = participant_from_ical(orga, &id_by_uri, orga,


### PR DESCRIPTION
This fixes a bug in the CalendarEvent/participantReply method, where the mboxevent is hard-coded to generate RFC8984-formatted JSCalendar data, irrespective if the client used the jscalendarbis capability.

The RFC 8984 implementation sets JSCalendar object identifiers using the X-JMAP-ID parameter on iCalendar properties, but the new jscalendarbis code sets the JSID parameter. As a consequence, reading iCalendar data generated from the new jscalendarbis code could make the mboxevent payload produce an invalid patch.

This commit updates the RFC8984 implementation to also support the JSID parameter. When trying to read an identifier from an iCalendar property, it first looks up the JSID parameter, then falls back reading to the former X-JMAP-ID parameter. This fixes the mboxevent patches to always produce the same output, independent of what capability the client used.