### PR TITLE
jscalendar.c: make version property mandatory for Event and Group

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_create_badname
+++ b/cassandane/tiny-tests/Caldav/calendar_create_badname
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_create_badname ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Starts with 'C' and <= 12 chars long
+    my $res = $CalDAV->SafeRequest('MKCALENDAR', 'C0123456789A');
+    $self->assert_num_equals(403, $res->{http_response}{status});
+
+    # Starts with 'c' and <= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCOL', 'c01234567890A');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+
+    # Starts with 'C' and >= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCALENDAR', 'C01234567890AB');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_migrate39_defaultalerts
@@ -166,6 +166,7 @@ sub assert_events ($self, $state)
             ['CalendarEvent/set', {
                 create => {
                     eventA => {
+                        version => "2.0",
                         calendarIds => {
                             $state->{calendarA}{id} => JSON::true,
                         },
@@ -176,6 +177,7 @@ sub assert_events ($self, $state)
                         useDefaultAlerts => JSON::true,
                     },
                     eventB1 => {
+                        version => "2.0",
                         calendarIds => {
                             $state->{calendarB}{id} => JSON::true,
                         },
@@ -186,6 +188,7 @@ sub assert_events ($self, $state)
                         useDefaultAlerts => JSON::true,
                     },
                     eventB2 => {
+                        version => "2.0",
                         calendarIds => {
                             $state->{calendarB}{id} => JSON::true,
                         },

--- a/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
+++ b/cassandane/tiny-tests/JMAPCalendars/admin_rewrite_calendarevent_privacy
@@ -34,6 +34,7 @@ sub test_admin_rewrite_calendarevent_privacy
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -56,6 +57,7 @@ sub test_admin_rewrite_calendarevent_privacy
                     },
                 },
                 event2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_defaultalerts_synctoken
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_defaultalerts_synctoken
@@ -37,6 +37,7 @@ sub test_calendar_defaultalerts_synctoken
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => "2.0",
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -55,6 +56,7 @@ sub test_calendar_defaultalerts_synctoken
                     },
                 },
                 2 => {
+                    version => "2.0",
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_defaultalerts_synctoken_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_defaultalerts_synctoken_shared
@@ -44,6 +44,7 @@ sub test_calendar_defaultalerts_synctoken_shared
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => "2.0",
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -62,6 +63,7 @@ sub test_calendar_defaultalerts_synctoken_shared
                     },
                 },
                 2 => {
+                    version => "2.0",
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_scheduling_enabled
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_scheduling_enabled
@@ -36,6 +36,7 @@ sub test_calendar_scheduling_enabled
     xlog $self, "send invitation as organizer to attendee";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_defaultalerts_shared
@@ -288,6 +288,7 @@ sub create_test ($self)
             accountId => 'owner',
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         Default => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
+++ b/cassandane/tiny-tests/JMAPCalendars/calendar_set_destroy_events
@@ -21,6 +21,7 @@ sub test_calendar_set_destroy_events
         ['CalendarEvent/set', {
             create => {
                 2 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         '#1' => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup
@@ -12,6 +12,7 @@ sub test_calendarevent_blob_lookup
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup_standalone_instances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_blob_lookup_standalone_instances
@@ -13,6 +13,7 @@ sub test_calendarevent_blob_lookup_standalone_instances ($self)
     xlog $self, "create the first standalone instance";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i1 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance1',
@@ -29,6 +30,7 @@ sub test_calendarevent_blob_lookup_standalone_instances ($self)
     xlog $self, "create a second standalone instance with the same uid";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i2 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance2',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_blobid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_blobid
@@ -30,6 +30,7 @@ sub test_calendarevent_blobid
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => "2.0",
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes
@@ -28,6 +28,7 @@ sub test_calendarevent_changes
     xlog $self, "create event #1 in calendar $calidA and event #2 in calendar $calidB";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calidA => JSON::true,
                             },
@@ -38,6 +39,7 @@ sub test_calendarevent_changes
                             "start" => "2015-10-06T00:00:00",
                         },
                         "2" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calidB => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_after_dav_reconstruct
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_after_dav_reconstruct
@@ -16,6 +16,7 @@ sub test_calendarevent_changes_after_dav_reconstruct ($self)
     xlog $self, "create an event";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         1 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             title => 'original',
             start => '2026-02-01T12:00:00',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_destroy_after_dav_reconstruct
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_destroy_after_dav_reconstruct
@@ -13,6 +13,7 @@ sub test_calendarevent_changes_destroy_after_dav_reconstruct ($self)
     xlog $self, "create an event";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         1 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             title => 'original',
             start => '2026-02-01T12:00:00',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_recreate_uid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_recreate_uid
@@ -16,6 +16,7 @@ sub test_calendarevent_changes_recreate_uid ($self)
     $res = $jmap->CallMethods([['CalendarEvent/set', {
         create => {
             "1" => {
+                "version" => "2.0",
                 uid => $uid,
                 calendarIds => {
                     $calId => JSON::true,
@@ -50,6 +51,7 @@ sub test_calendarevent_changes_recreate_uid ($self)
     $res = $jmap->CallMethods([['CalendarEvent/set', {
         create => {
             "1" => {
+                "version" => "2.0",
                 uid => $uid,
                 calendarIds => {
                     $calId => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_standalone_after_dav_reconstruct
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_standalone_after_dav_reconstruct
@@ -22,6 +22,7 @@ sub test_calendarevent_changes_standalone_after_dav_reconstruct ($self)
     xlog $self, "create the first standalone instance";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i1 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance1',
@@ -38,6 +39,7 @@ sub test_calendarevent_changes_standalone_after_dav_reconstruct ($self)
     xlog $self, "create a second standalone instance with the same uid";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i2 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance2',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_standalone_destroy_after_dav_reconstruct
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_changes_standalone_destroy_after_dav_reconstruct
@@ -11,6 +11,7 @@ sub test_calendarevent_changes_standalone_destroy_after_dav_reconstruct ($self)
     xlog $self, "create the first standalone instance";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i1 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance1',
@@ -30,6 +31,7 @@ sub test_calendarevent_changes_standalone_destroy_after_dav_reconstruct ($self)
     xlog $self, "create a second standalone instance with the same uid";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         i2 => {
+            version => '2.0',
             calendarIds => { $calid => JSON::true },
             uid => 'event1uid',
             title => 'instance2',

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy
@@ -44,6 +44,7 @@ sub test_calendarevent_copy
     $admintalk->setacl("user.other.#calendars.$dstCalendarId", "cassandane" => 'lrswipkxtecdn') or die;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $srcCalendarJmapId => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy_state
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_copy_state
@@ -42,6 +42,7 @@ sub test_calendarevent_copy_state ($self)
     $admintalk->setacl("user.other.#calendars.$dstCalendarId", "cassandane" => 'lrswipkxtecdn') or die;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $srcCalendarJmapId => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_debugblobid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_debugblobid
@@ -30,6 +30,7 @@ sub test_calendarevent_debugblobid
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => "2.0",
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_etag_preserved_after_alarm
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_etag_preserved_after_alarm
@@ -43,6 +43,7 @@ sub test_calendarevent_defaultalerts_etag_preserved_after_alarm
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => "2.0",
                     uid => $eventUid,
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_updated_by_caldav_put
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_defaultalerts_updated_by_caldav_put
@@ -125,6 +125,7 @@ sub create_jevent ($self)
         ['CalendarEvent/set', {
             create => {
                 $eventUid => {
+                    version => "2.0",
                     uid => $eventUid,
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_encode_imip_uri
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_encode_imip_uri
@@ -26,6 +26,7 @@ EOF
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_baseeventid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_baseeventid
@@ -15,6 +15,7 @@ sub test_calendarevent_get_baseeventid
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -35,6 +36,7 @@ sub test_calendarevent_get_baseeventid
                     },
                 },
                 event2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_isorigin
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_isorigin
@@ -13,6 +13,7 @@ sub test_calendarevent_get_isorigin
         ['CalendarEvent/set', {
             create => {
                 eventNoReplyTo => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -23,6 +24,7 @@ sub test_calendarevent_get_isorigin
                     duration => 'PT1H',
                 },
                 eventIsOrganizer => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -39,6 +41,7 @@ sub test_calendarevent_get_isorigin
                     },
                 },
                 eventIsInvitee => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_privacy_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_privacy_shared
@@ -30,6 +30,7 @@ sub test_calendarevent_get_privacy_shared
 
     xlog "create fullblown event for each privacy setting";
     my $eventTemplate = {
+        version => '2.0',
         calendarIds => {
             $default_cal_id => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceinstances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceinstances
@@ -15,6 +15,7 @@ sub test_calendarevent_get_recurrenceinstances
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceoverrides_before_after
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_recurrenceoverrides_before_after
@@ -15,6 +15,7 @@ sub test_calendarevent_get_recurrenceoverrides_before_after
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reducepartitipants
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reducepartitipants
@@ -14,6 +14,7 @@ sub test_calendarevent_get_reducepartitipants
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reset_iter
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_reset_iter
@@ -22,6 +22,7 @@ sub test_calendarevent_get_reset_iter
         ['CalendarEvent/set', {
             create => {
                 eventA => {
+                    version => '2.0',
                     calendarIds => {
                         '#calendarA' => JSON::true,
                     },
@@ -33,6 +34,7 @@ sub test_calendarevent_get_reset_iter
                     duration => 'PT1H',
                 },
                 eventB => {
+                    version => '2.0',
                     calendarIds => {
                         '#calendarB' => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_utcstart
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_get_utcstart
@@ -25,6 +25,7 @@ sub test_calendarevent_get_utcstart
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -81,6 +82,7 @@ sub test_calendarevent_get_utcstart
         ['CalendarEvent/set', {
             create => {
                 2 => {
+                    version => '2.0',
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts
@@ -50,6 +50,7 @@ sub test_calendarevent_multiget_defaultalerts
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => '5f0dec98-8952-418e-91fa-159cb2ba28da',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts_per_calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_multiget_defaultalerts_per_calendar
@@ -54,6 +54,7 @@ sub test_calendarevent_multiget_defaultalerts_per_calendar
         ['CalendarEvent/set', {
             create => {
                 eventA1 => {
+                    version => '2.0',
                     uid => '5f0dec98-8952-418e-91fa-159cb2ba28da',
                     calendarIds => {
                         $calendarAId => JSON::true,
@@ -65,6 +66,7 @@ sub test_calendarevent_multiget_defaultalerts_per_calendar
                     useDefaultAlerts => JSON::true,
                 },
                 eventA2 => {
+                    version => '2.0',
                     uid => '68b31869-889e-49f2-ac6a-f94ce0179635',
                     calendarIds => {
                         $calendarAId => JSON::true,
@@ -76,6 +78,7 @@ sub test_calendarevent_multiget_defaultalerts_per_calendar
                     useDefaultAlerts => JSON::true,
                 },
                 eventB1 => {
+                    version => '2.0',
                     uid => 'b58fcc34-aca6-4ae5-a7d0-97411d1166a4',
                     calendarIds => {
                         $calendarBId => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_organizer_noattendees
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_organizer_noattendees
@@ -69,6 +69,7 @@ sub test_calendarevent_organizer_noattendees
         ['CalendarEvent/set', {
             create => {
                 event2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_plusaddr
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_plusaddr
@@ -45,6 +45,7 @@ sub test_calendarevent_participantreply_plusaddr
     xlog $self, "create scheduled event";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_simple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_simple
@@ -49,6 +49,7 @@ sub test_calendarevent_participantreply_simple
     xlog $self, "create scheduled event";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_standalone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_participantreply_standalone
@@ -47,6 +47,7 @@ sub test_calendarevent_participantreply_standalone
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query
@@ -42,6 +42,7 @@ sub test_calendarevent_query
         ['CalendarEvent/set', {
             create => {
                 eventA1 => {
+                    version => '2.0',
                     calendarIds => {
                         $calendarIdA => JSON::true,
                     },
@@ -53,6 +54,7 @@ sub test_calendarevent_query
                     duration => 'PT1H',
                 },
                 eventB1 => {
+                    version => '2.0',
                     calendarIds => {
                         $calendarIdB => JSON::true,
                     },
@@ -64,6 +66,7 @@ sub test_calendarevent_query
                     duration => 'PT1H',
                 },
                 eventA2 => {
+                    version => '2.0',
                     calendarIds => {
                         $calendarIdA => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_anchor
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_anchor
@@ -14,6 +14,7 @@ sub test_calendarevent_query_anchor
         ['CalendarEvent/set', {
             create => {
                 '1' => {
+                    'version' => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },
@@ -23,6 +24,7 @@ sub test_calendarevent_query_anchor
                     'timeZone' => 'Etc/UTC',
                 },
                 '2' => {
+                    'version' => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },
@@ -32,6 +34,7 @@ sub test_calendarevent_query_anchor
                     'timeZone' => 'Etc/UTC',
                 },
                 '3' => {
+                    'version' => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_date
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_date
@@ -14,6 +14,7 @@ sub test_calendarevent_query_date
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         # Start: 2016-01-01 End: 2016-01-03
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },
@@ -104,6 +105,7 @@ sub test_calendarevent_query_date
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         # Start: 2017-01-01T08:00:00Z End: eternity
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_datetime
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_datetime
@@ -14,6 +14,7 @@ sub test_calendarevent_query_datetime
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         # Start: 2016-01-01T08:00:00Z End: 2016-01-01T09:00:00Z
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },
@@ -82,6 +83,7 @@ sub test_calendarevent_query_datetime
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         # Start: 2017-01-01T08:00:00Z End: eternity
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_deleted_calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_deleted_calendar
@@ -30,6 +30,7 @@ sub test_calendarevent_query_deleted_calendar
     $res = $jmap->CallMethods([['CalendarEvent/set', {
                     create => {
                         "1" => {
+                            "version" => "2.0",
                             "calendarIds" => {
                                 $calidA => JSON::true,
                             },
@@ -42,6 +43,7 @@ sub test_calendarevent_query_deleted_calendar
                             "duration" => "PT1H",
                         },
                         "2" => {
+                            "version" => "2.0",
                             "calendarIds" => {
                                 $calidB => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_expandrecurrences
@@ -15,6 +15,7 @@ sub test_calendarevent_query_expandrecurrences
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },
@@ -39,6 +40,7 @@ sub test_calendarevent_query_expandrecurrences
                     },
                 },
                 "2" => {
+                    version => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_shared
@@ -59,6 +59,7 @@ sub test_calendarevent_query_shared
                         accountId => $account,
                         create => {
                             "1" => {
+                                "version" => "2.0",
                                 calendarIds => {
                                     $calidA => JSON::true,
                                 },
@@ -71,6 +72,7 @@ sub test_calendarevent_query_shared
                                 "duration" => "PT1H",
                             },
                             "2" => {
+                                "version" => "2.0",
                                 calendarIds => {
                                     $calidB => JSON::true,
                                 },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_sort
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_sort
@@ -14,6 +14,7 @@ sub test_calendarevent_query_sort
         ['CalendarEvent/set', {
             create => {
                 '1' => {
+                    'version' => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },
@@ -23,6 +24,7 @@ sub test_calendarevent_query_sort
                     'timeZone' => 'Etc/UTC',
                 },
                 '2' => {
+                    'version' => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_text
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_text
@@ -12,6 +12,7 @@ sub test_calendarevent_query_text
 
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unixepoch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_unixepoch
@@ -13,6 +13,7 @@ sub test_calendarevent_query_unixepoch
     xlog $self, "create events";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
       "1" => {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_with_timezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_query_with_timezone
@@ -13,6 +13,7 @@ sub test_calendarevent_query_with_timezone
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts
@@ -55,6 +55,7 @@ sub test_calendarevent_set_alerts
     };
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_description
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_description
@@ -12,6 +12,7 @@ sub test_calendarevent_set_alerts_description
         ['CalendarEvent/set', {
             create => {
                 1 =>  {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -30,6 +31,7 @@ sub test_calendarevent_set_alerts_description
                     },
                 },
                 2 =>  {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -47,6 +49,7 @@ sub test_calendarevent_set_alerts_description
                     },
                 },
                 3 =>  {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_alerts_owner
@@ -43,6 +43,7 @@ sub test_calendarevent_set_alerts_owner
             accountId => 'cassandane',
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_attachbinary_datauri
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_attachbinary_datauri
@@ -15,6 +15,7 @@ sub test_calendarevent_set_attachbinary_datauri
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_baseeventid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_baseeventid
@@ -15,6 +15,7 @@ sub test_calendarevent_set_baseeventid
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -30,6 +31,7 @@ sub test_calendarevent_set_baseeventid
 
                 },
                 event2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -86,6 +88,7 @@ sub test_calendarevent_set_baseeventid
         ['CalendarEvent/set', {
             create => {
                 rdate => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bymonth
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_bymonth
@@ -10,6 +10,7 @@ sub test_calendarevent_set_bymonth
         my $calid = $self->default_user->calendars->default->id;
 
         my $event =  {
+                "version" => "2.0",
                 calendarIds => {
                     $calid => JSON::true,
                 },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_caldav
@@ -22,6 +22,7 @@ sub test_calendarevent_set_caldav
     xlog $self, "create event in calendar";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_color
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_color
@@ -8,6 +8,7 @@ sub test_calendarevent_set_color
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        version => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_ignore_uid_in_special_calendar
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_ignore_uid_in_special_calendar
@@ -74,6 +74,7 @@ EOF
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_null_values
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_create_null_values
@@ -14,6 +14,7 @@ sub test_calendarevent_set_create_null_values
         # Mandatory properties
         calendarIds => { $calid => JSON::true },
         start => '2026-01-02T03:04:05',
+        version => '2.0',
         # Optional properties
         alerts => undef,
         categories => undef,
@@ -48,7 +49,6 @@ sub test_calendarevent_set_create_null_values
         title => undef,
         uid => undef,
         updated => undef,
-        version => undef,
         virtualLocations => undef,
     };
 

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_created
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_created
@@ -20,6 +20,7 @@ sub test_calendarevent_set_created
         ['CalendarEvent/set', {
             create => {
                 eventNoCreated => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -29,6 +30,7 @@ sub test_calendarevent_set_created
                     title => 'eventNoCreated',
                 },
                 eventCreatedInPast => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -39,6 +41,7 @@ sub test_calendarevent_set_created
                     created => $past,
                 },
                 eventCreatedInFuture => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts
@@ -43,6 +43,7 @@ sub test_calendarevent_set_defaultalerts
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -54,6 +55,7 @@ sub test_calendarevent_set_defaultalerts
                     useDefaultAlerts => JSON::true,
                 },
                 2 => {
+                    version => '2.0',
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_etag
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_etag
@@ -37,6 +37,7 @@ sub test_calendarevent_set_defaultalerts_caldav_etag
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     uid => '0b610a32-82ca-48b0-a01e-a77bcf932242',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -48,6 +49,7 @@ sub test_calendarevent_set_defaultalerts_caldav_etag
                     useDefaultAlerts => JSON::true,
                 },
                 event2 => {
+                    version => '2.0',
                     uid => '9c908bf3-f69e-4fc3-8c0f-1986342f1fe5',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_xapple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_caldav_xapple
@@ -37,6 +37,7 @@ sub test_calendarevent_set_defaultalerts_caldav_xapple
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_description
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_description
@@ -32,6 +32,7 @@ sub test_calendarevent_set_defaultalerts_description
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_etag
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_etag
@@ -32,6 +32,7 @@ sub test_calendarevent_set_defaultalerts_etag
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -43,6 +44,7 @@ sub test_calendarevent_set_defaultalerts_etag
                     useDefaultAlerts => JSON::true,
                 },
                 2 => {
+                    version => '2.0',
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_etag_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_defaultalerts_etag_shared
@@ -44,6 +44,7 @@ sub test_calendarevent_set_defaultalerts_etag_shared
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone
@@ -9,6 +9,7 @@ sub test_calendarevent_set_endtimezone
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone_recurrence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_endtimezone_recurrence
@@ -9,6 +9,7 @@ sub test_calendarevent_set_endtimezone_recurrence
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_fullblown
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_fullblown
@@ -11,6 +11,7 @@ sub test_calendarevent_set_fullblown
     my ($maj, $min) = Cassandane::Instance->get_version();
 
     my $event1 = {
+        version => '2.0',
         calendarIds => {
             $default_cal_id => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_htmldescription
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_htmldescription
@@ -9,6 +9,7 @@ sub test_calendarevent_set_htmldescription
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_invalidpatch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_invalidpatch
@@ -12,6 +12,7 @@ sub test_calendarevent_set_invalidpatch
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_isdraft
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_isdraft
@@ -15,6 +15,7 @@ sub test_calendarevent_set_isdraft
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    "version" => "2.0",
                     calendarIds => {
                         $calid => JSON::true,
                     },
@@ -25,6 +26,7 @@ sub test_calendarevent_set_isdraft
                     "isDraft" => JSON::true,
                 },
                 2 => {
+                    "version" => "2.0",
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_itip_preserve_partstat
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_itip_preserve_partstat
@@ -17,6 +17,7 @@ sub test_calendarevent_set_itip_preserve_partstat
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords
@@ -9,6 +9,7 @@ sub test_calendarevent_set_keywords
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_keywords_patch
@@ -9,6 +9,7 @@ sub test_calendarevent_set_keywords_patch
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links
@@ -9,6 +9,7 @@ sub test_calendarevent_set_links
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_dupids
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_links_dupids
@@ -9,6 +9,7 @@ sub test_calendarevent_set_links_dupids
     my $default_cal_id = $self->default_user->calendars->default->id;
 
     my $event =  {
+        version => '2.0',
         calendarIds => {
             $default_cal_id => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_locations
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_locations
@@ -55,6 +55,7 @@ sub test_calendarevent_set_locations
     };
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_mayinvite_preserve_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_mayinvite_preserve_caldav
@@ -15,6 +15,7 @@ sub test_calendarevent_set_mayinvite_preserve_caldav
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_method
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_method
@@ -13,6 +13,7 @@ sub test_calendarevent_set_method
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -41,6 +42,7 @@ sub test_calendarevent_set_method
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move
@@ -26,6 +26,7 @@ sub test_calendarevent_set_move
     xlog $self, "create event in calendar $calidA";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calidA => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move_fast_path
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_move_fast_path
@@ -25,6 +25,7 @@ sub test_calendarevent_set_move_fast_path
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $src_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_notitle
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_notitle
@@ -9,6 +9,7 @@ sub test_calendarevent_set_notitle
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_organizer
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_organizer
@@ -11,6 +11,7 @@ sub test_calendarevent_set_organizer
         ['CalendarEvent/set', {
             create => {
                 eventReplyTo => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -26,6 +27,7 @@ sub test_calendarevent_set_organizer
                     },
                 },
                 eventNoReplyTo => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -40,6 +42,7 @@ sub test_calendarevent_set_organizer
                     },
                 },
                 eventReplyToNoParticipants => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -50,6 +53,7 @@ sub test_calendarevent_set_organizer
                     organizerCalendarAddress => 'mailto:cassandane@example.com',
                 },
                 eventNoScheduling => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participantid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participantid
@@ -25,6 +25,7 @@ sub test_calendarevent_set_participantid
     };
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants
@@ -10,6 +10,7 @@ sub test_calendarevent_set_participants
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_justorga
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_justorga
@@ -10,6 +10,7 @@ sub test_calendarevent_set_participants_justorga
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_organame
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_organame
@@ -10,6 +10,7 @@ sub test_calendarevent_set_participants_organame
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_patch
@@ -10,6 +10,7 @@ sub test_calendarevent_set_participants_patch
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_recur
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_participants_recur
@@ -10,6 +10,7 @@ sub test_calendarevent_set_participants_recur
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_peruser
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_peruser
@@ -31,6 +31,7 @@ sub test_calendarevent_set_peruser
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_peruser_secretary
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_peruser_secretary
@@ -59,6 +59,7 @@ EOF
     my @proplist = keys %$perUserProps;
 
     my $event = {
+        version => '2.0',
         uid => 'eventuid1',
         calendarIds => {
             $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_plusaddr_itip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_plusaddr_itip
@@ -35,6 +35,7 @@ EOF
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy
@@ -39,6 +39,7 @@ sub test_calendarevent_set_privacy
             accountId => 'sharer',
             create => {
                 eventShared1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -48,6 +49,7 @@ sub test_calendarevent_set_privacy
                     privacy => 'public',
                 },
                 eventShared2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -61,6 +63,7 @@ sub test_calendarevent_set_privacy
         ['CalendarEvent/set', {
             create => {
                 eventOwned1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_ignore_override
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_ignore_override
@@ -15,6 +15,7 @@ sub test_calendarevent_set_privacy_ignore_override
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_private_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_private_shared
@@ -39,6 +39,7 @@ sub test_calendarevent_set_privacy_private_shared
         ['CalendarEvent/set', {
             create => {
                 privateEvent => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_secret_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_privacy_secret_shared
@@ -39,6 +39,7 @@ sub test_calendarevent_set_privacy_secret_shared
         ['CalendarEvent/set', {
             create => {
                 secretEvent => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_prodid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_prodid
@@ -9,6 +9,7 @@ sub test_calendarevent_set_prodid
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence
@@ -23,6 +23,7 @@ sub test_calendarevent_set_recurrence
     };
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_bymonthday
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_bymonthday
@@ -10,6 +10,7 @@ sub test_calendarevent_set_recurrence_bymonthday
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         "uid" => "90c2697e-acbc-4508-9e72-6b8828e8d9f3",
         calendarIds => {
             $calid => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_patch
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_patch
@@ -13,6 +13,7 @@ sub test_calendarevent_set_recurrence_patch
         ['CalendarEvent/set', {
             create =>  {
                 1 => {
+                    "version" => "2.0",
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_until
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_until
@@ -10,6 +10,7 @@ sub test_calendarevent_set_recurrence_until
     my $calid = $self->default_user->calendars->default->id;
 
     my $event = {
+        "version" => "2.0",
         "status" =>"confirmed",
         calendarIds => {
             $calid => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_untilallday
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrence_untilallday
@@ -10,6 +10,7 @@ sub test_calendarevent_set_recurrence_untilallday
     my $calid = $self->default_user->calendars->default->id;
 
     my $event = {
+        "version" => "2.0",
         "status" =>"confirmed",
         calendarIds => {
             $calid => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances
@@ -15,6 +15,7 @@ sub test_calendarevent_set_recurrenceinstances
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances_rdate
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceinstances_rdate
@@ -15,6 +15,7 @@ sub test_calendarevent_set_recurrenceinstances_rdate
         ['CalendarEvent/set', {
             create => {
                 "1" => {
+                    version => '2.0',
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceoverrides
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_recurrenceoverrides
@@ -10,6 +10,7 @@ sub test_calendarevent_set_recurrenceoverrides
     my $calid = $self->default_user->calendars->default->id;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_reject_duplicate_uid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_reject_duplicate_uid
@@ -12,6 +12,7 @@ sub test_calendarevent_set_reject_duplicate_uid
         ['CalendarEvent/set', {
             create => {
                 eventA => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -36,6 +37,7 @@ sub test_calendarevent_set_reject_duplicate_uid
         ['CalendarEvent/set', {
             create => {
                 eventB => {
+                    version => '2.0',
                     calendarIds => {
                         '#calendarB' => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_relatedto
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_relatedto
@@ -9,6 +9,7 @@ sub test_calendarevent_set_relatedto
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_replace_standalone_with_destroy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_replace_standalone_with_destroy
@@ -13,6 +13,7 @@ sub test_calendarevent_set_replace_standalone_with_destroy
         ['CalendarEvent/set', {
             create => {
                 instance => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -36,6 +37,7 @@ sub test_calendarevent_set_replace_standalone_with_destroy
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_reply_partstat_changed
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_reply_partstat_changed
@@ -16,6 +16,7 @@ sub test_calendarevent_set_reply_partstat_changed
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_cancel
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_cancel
@@ -20,6 +20,7 @@ sub test_calendarevent_set_schedule_cancel
     xlog $self, "send invitation as organizer";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_destroy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_destroy
@@ -20,6 +20,7 @@ sub test_calendarevent_set_schedule_destroy
     xlog $self, "send invitation as organizer";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_reply
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_reply
@@ -27,6 +27,7 @@ sub test_calendarevent_set_schedule_reply
     xlog $self, "create event";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
         "1" => {
+            "version" => "2.0",
             calendarIds => {
                 $default_cal_id => JSON::true,
             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request
@@ -30,6 +30,7 @@ sub test_calendarevent_set_schedule_request
     xlog $self, "send invitation as organizer to attendee";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request_add_participant
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedule_request_add_participant
@@ -30,6 +30,7 @@ sub test_calendarevent_set_schedule_request_add_participant
     xlog $self, "send invitation as organizer to attendee";
     my $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             calendarIds => {
                                 $default_cal_id => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedulingmessages
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_schedulingmessages
@@ -17,6 +17,7 @@ sub test_calendarevent_set_schedulingmessages
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_sentby
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_sentby
@@ -12,6 +12,7 @@ sub test_calendarevent_set_sentby
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_shared
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_shared
@@ -37,6 +37,7 @@ sub test_calendarevent_set_shared
     $admintalk->setacl("user.manifold.#calendars.$CalendarId1", "cassandane" => 'lr') or die;
 
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $CalendarId1 => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_simple
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_simple
@@ -9,6 +9,7 @@ sub test_calendarevent_set_simple
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_create
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_create
@@ -23,6 +23,7 @@ sub test_calendarevent_set_standalone_instances_create
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -70,6 +71,7 @@ sub test_calendarevent_set_standalone_instances_create
         ['CalendarEvent/set', {
             create => {
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -104,6 +106,7 @@ sub test_calendarevent_set_standalone_instances_create
         ['CalendarEvent/set', {
             create => {
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_destroy
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_destroy
@@ -15,6 +15,7 @@ sub test_calendarevent_set_standalone_instances_destroy
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -28,6 +29,7 @@ sub test_calendarevent_set_standalone_instances_destroy
                     recurrenceIdTimeZone => 'Europe/London',
                 },
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_move
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_move
@@ -15,6 +15,7 @@ sub test_calendarevent_set_standalone_instances_move
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -28,6 +29,7 @@ sub test_calendarevent_set_standalone_instances_move
                     recurrenceIdTimeZone => 'Europe/London',
                 },
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_to_main
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_to_main
@@ -15,6 +15,7 @@ sub test_calendarevent_set_standalone_instances_to_main
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -63,6 +64,7 @@ sub test_calendarevent_set_standalone_instances_to_main
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_update
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_instances_update
@@ -15,6 +15,7 @@ sub test_calendarevent_set_standalone_instances_update
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -28,6 +29,7 @@ sub test_calendarevent_set_standalone_instances_update
                     recurrenceIdTimeZone => 'Europe/London',
                 },
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_itip
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_standalone_itip
@@ -23,6 +23,7 @@ sub test_calendarevent_set_standalone_itip
         ['CalendarEvent/set', {
             create => {
                 instance1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -84,6 +85,7 @@ sub test_calendarevent_set_standalone_itip
         ['CalendarEvent/set', {
             create => {
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -187,6 +189,7 @@ sub test_calendarevent_set_standalone_itip
         ['CalendarEvent/set', {
             create => {
                 instance2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_too_large
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_too_large
@@ -21,6 +21,7 @@ sub test_calendarevent_set_too_large
     xlog $self, "create event in calendar";
     $res = $jmap->CallMethods([['CalendarEvent/set', { create => {
                         "1" => {
+                            "version" => "2.0",
                             "calendarIds" => {
                                 $calid => JSON::true,
                             },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_type
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_type
@@ -9,6 +9,7 @@ sub test_calendarevent_set_type
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_uid
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_uid
@@ -9,6 +9,7 @@ sub test_calendarevent_set_uid
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated
@@ -18,6 +18,7 @@ sub test_calendarevent_set_updated
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_not_source
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_not_source
@@ -20,6 +20,7 @@ sub test_calendarevent_set_updated_scheduled_not_source
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_source
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_updated_scheduled_source
@@ -20,6 +20,7 @@ sub test_calendarevent_set_updated_scheduled_source
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_utcstart
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_utcstart
@@ -13,6 +13,7 @@ sub test_calendarevent_set_utcstart
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -23,6 +24,7 @@ sub test_calendarevent_set_utcstart
                     timeZone => "Australia/Melbourne",
                 },
                 2 => {
+                    version => '2.0',
                     uid => 'eventuid2local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_utcstart_recur
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_utcstart_recur
@@ -23,6 +23,7 @@ sub test_calendarevent_set_utcstart_recur
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_virtuallocation_xprop
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_set_virtuallocation_xprop
@@ -21,6 +21,7 @@ sub test_calendarevent_set_virtuallocation_xprop ($self)
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarevent_utcstart_customtz
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarevent_utcstart_customtz
@@ -54,6 +54,7 @@ EOF
         ['CalendarEvent/set', {
             create => {
                 1 => {
+                    version => '2.0',
                     uid => 'eventuid1local',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_aclcheck
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_aclcheck
@@ -59,6 +59,7 @@ sub test_calendareventnotification_aclcheck
         ['CalendarEvent/set', {
             create => {
                 sharedEvent => {
+                    version => '2.0',
                     title => 'sharedEvent',
                     calendarIds => {
                         $sharedCalendarId => JSON::true,
@@ -67,6 +68,7 @@ sub test_calendareventnotification_aclcheck
                     duration => 'PT1H',
                 },
                 unsharedEvent => {
+                    version => '2.0',
                     title => 'unsharedEvent',
                     calendarIds => {
                         $unsharedCalendarId => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_get
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_get
@@ -42,6 +42,7 @@ sub test_calendareventnotification_get
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     title => 'event1',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_get_no_sharee
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_get_no_sharee
@@ -19,6 +19,7 @@ sub test_calendareventnotification_get_no_sharee
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     title => 'event1',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_prune
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_prune
@@ -46,6 +46,7 @@ sub test_calendareventnotification_prune
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     title => 'event1',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -74,6 +75,7 @@ sub test_calendareventnotification_prune
             ['CalendarEvent/set', {
                 create => {
                     "event$i" => {
+                        version => '2.0',
                         title => "event$i",
                         calendarIds => {
                             $default_cal_id => JSON::true,
@@ -104,6 +106,7 @@ sub test_calendareventnotification_prune
         ['CalendarEvent/set', {
             create => {
                 eventX => {
+                    version => '2.0',
                     title => 'eventX',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_query
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_query
@@ -47,6 +47,7 @@ sub test_calendareventnotification_query
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     title => 'event1',
                     calendarIds => {
                         $default_cal_id => JSON::true,
@@ -120,6 +121,7 @@ sub test_calendareventnotification_query
         ['CalendarEvent/set', {
             create => {
                 event2 => {
+                    version => '2.0',
                     title => 'event2',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_set
+++ b/cassandane/tiny-tests/JMAPCalendars/calendareventnotification_set
@@ -42,6 +42,7 @@ sub test_calendareventnotification_set
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     title => 'event1',
                     calendarIds => {
                         $default_cal_id => JSON::true,

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_merged
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_merged
@@ -13,6 +13,7 @@ sub test_calendarprincipal_getavailability_merged
             create => {
                 # 09:00 to 10:30: Two events adjacent to each other.
                 'event-0900-1000' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -22,6 +23,7 @@ sub test_calendarprincipal_getavailability_merged
                     duration => "PT1H",
                 },
                 'event-1000-1030' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -32,6 +34,7 @@ sub test_calendarprincipal_getavailability_merged
                 },
                 # 05:00 to 08:00: One event completely overlapping the other.
                 'event-0500-0800' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -41,6 +44,7 @@ sub test_calendarprincipal_getavailability_merged
                     duration => "PT3H",
                 },
                 'event-0600-0700' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -51,6 +55,7 @@ sub test_calendarprincipal_getavailability_merged
                 },
                 # 01:00 to 03:00: One event partially overlapping the other.
                 'event-0100-0200' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -60,6 +65,7 @@ sub test_calendarprincipal_getavailability_merged
                     duration => "PT1H",
                 },
                 'event-0130-0300' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -70,6 +76,7 @@ sub test_calendarprincipal_getavailability_merged
                 },
                 # 12:00 to 13:30: Overlapping events with differing busyStatus.
                 'event-1200-1300-tentative' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -80,6 +87,7 @@ sub test_calendarprincipal_getavailability_merged
                     status => 'tentative',
                 },
                 'event-1200-1330-confirmed' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -90,6 +98,7 @@ sub test_calendarprincipal_getavailability_merged
                     status => 'confirmed',
                 },
                 'event-1200-1230-unavailable' => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_showdetails
+++ b/cassandane/tiny-tests/JMAPCalendars/calendarprincipal_getavailability_showdetails
@@ -25,6 +25,7 @@ sub test_calendarprincipal_getavailability_showdetails
         ['CalendarEvent/set', {
             create => {
                 event1 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -46,6 +47,7 @@ sub test_calendarprincipal_getavailability_showdetails
                     },
                 },
                 event2 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -56,6 +58,7 @@ sub test_calendarprincipal_getavailability_showdetails
                     duration => "PT3H",
                 },
                 event3 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -67,6 +70,7 @@ sub test_calendarprincipal_getavailability_showdetails
                     freeBusyStatus => 'free',
                 },
                 event4 => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },
@@ -78,6 +82,7 @@ sub test_calendarprincipal_getavailability_showdetails
                     status => 'tentative',
                 },
                 event5 => {
+                    version => '2.0',
                     calendarIds => {
                         $invisibleCalendarId => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/crasher20191227
+++ b/cassandane/tiny-tests/JMAPCalendars/crasher20191227
@@ -13,6 +13,7 @@ sub test_crasher20191227
         ['CalendarEvent/set', {
             create => {
                 event1 =>  {
+                    "version" => "2.0",
                     calendarIds => {
                         $calid => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/itip_request_tzid_change
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_request_tzid_change
@@ -18,6 +18,7 @@ sub test_itip_request_tzid_change
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/itip_request_with_transp
+++ b/cassandane/tiny-tests/JMAPCalendars/itip_request_with_transp
@@ -16,6 +16,7 @@ sub test_itip_request_with_transp
         ['CalendarEvent/set', {
             create => {
                 event => {
+                    version => '2.0',
                     calendarIds => {
                         $default_cal_id => JSON::true,
                     },

--- a/cassandane/tiny-tests/JMAPCalendars/misc_creationids
+++ b/cassandane/tiny-tests/JMAPCalendars/misc_creationids
@@ -16,6 +16,7 @@ sub test_misc_creationids
             isVisible => \1,
         }}}, 'R1'],
         ['CalendarEvent/set', { create => { "e1" => {
+            "version" => "2.0",
             calendarIds => {
                 '#c1' => JSON::true,
             },

--- a/cassandane/tiny-tests/JMAPCalendars/misc_timezone_expansion
+++ b/cassandane/tiny-tests/JMAPCalendars/misc_timezone_expansion
@@ -9,6 +9,7 @@ sub test_misc_timezone_expansion
 
     my $calid = $self->default_user->calendars->default->id;
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
+++ b/cassandane/tiny-tests/JMAPCalendars/rscale_in_jmap_hidden_in_caldav
@@ -13,6 +13,7 @@ sub test_rscale_in_jmap_hidden_in_caldav
     my $calid = $self->default_user->calendars->default->id;
     my $href = $self->default_user->calendars->default->properties->{'x-href'};
     my $event =  {
+        "version" => "2.0",
         calendarIds => {
             $calid => JSON::true,
         },

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -103,6 +103,7 @@ struct partial_caldata_t {
 static int meth_options_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_fb(struct transaction_t *txn, void *params);
+static int meth_mkcalendar(struct transaction_t *txn, void *params);
 
 static void my_caldav_init(struct buf *serverinfo);
 static int my_caldav_auth(const char *userid);
@@ -618,8 +619,8 @@ struct namespace_t namespace_calendar = {
         { &meth_get_head_cal,   &caldav_params },       /* GET          */
         { &meth_get_head_cal,   &caldav_params },       /* HEAD         */
         { &meth_lock,           &caldav_params },       /* LOCK         */
-        { &meth_mkcol,          &caldav_params },       /* MKCALENDAR   */
-        { &meth_mkcol,          &caldav_params },       /* MKCOL        */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCALENDAR   */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
         { &meth_patch,          &caldav_params },       /* PATCH        */
@@ -2689,6 +2690,48 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     /* Unknown action */
     return HTTP_NO_CONTENT;
+}
+
+static int meth_mkcalendar(struct transaction_t *txn, void *params)
+{
+    int r = 0;
+
+    /* Parse the path (use our own entry to suppress lookup) */
+    txn->req_tgt.mbentry = mboxlist_entry_create();
+    r = caldav_parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+
+    /* Make sure method is allowed (only allowed on child of home-set) */
+    if (!txn->req_tgt.collection || txn->req_tgt.resource ||
+        (txn->req_tgt.collection[0] == 'C' &&
+         txn->req_tgt.collen <= CONV_JMAPID_SIZE + 1)) {
+        txn->error.precond = CALDAV_LOCATION_OK;
+        return HTTP_FORBIDDEN;
+    }
+    else if (r) {
+        switch (r) {
+        case IMAP_MAILBOX_EXISTS:
+            txn->error.precond = DAV_RES_EXISTS;
+            break;
+                
+        case IMAP_PERMISSION_DENIED:
+            txn->error.precond = DAV_NEED_PRIVS;
+            txn->error.rights = DACL_BIND;
+            buf_reset(&txn->buf);
+            buf_printf(&txn->buf, "%s/%s/%s",
+                       txn->req_tgt.namespace->prefix, USER_COLLECTION_PREFIX,
+                       txn->req_tgt.userid);
+            txn->error.resource = buf_cstring(&txn->buf);
+            break;
+                
+        default:
+            txn->error.precond = CALDAV_LOCATION_OK;
+            break;
+        }
+
+        return HTTP_FORBIDDEN;
+    }
+
+    return meth_mkcol(txn, params);
 }
 
 /* Perform post-create MKCOL/MKCALENDAR processing */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5697,9 +5697,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
     /* Response should not be cached */
     txn->flags.cc |= CC_NOCACHE;
 
-    /* Parse the path (use our own entry to suppress lookup) */
-    txn->req_tgt.mbentry = mboxlist_entry_create();
-    r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    if (!txn->req_tgt.mbentry) {
+        /* Parse the path (use our own entry to suppress lookup) */
+        txn->req_tgt.mbentry = mboxlist_entry_create();
+        r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    }
 
     /* Make sure method is allowed (only allowed on child of home-set) */
     if (!txn->req_tgt.collection || txn->req_tgt.resource) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -700,6 +700,14 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
         free(xhref);
     }
 
+    if (jmap_wantprop(rock->get->props, "x-compactId")) {
+        struct conversations_state cstate =
+            { .version = 2, .compact_emailids = 1 }; // force compactId
+        char compactid[JMAP_MAX_CALENDARID_SIZE];
+        jmap_set_calendarid(&cstate, mbentry, compactid);
+        json_object_set_new(obj, "x-compactId", json_string(compactid));
+    }
+    
     if (jmap_wantprop(rock->get->props, "name")) {
         buf_reset(&attrib);
         static const char *displayname_annot =

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -1242,13 +1242,18 @@ static icalcomponent *alert_to_ical(jmap_req_t *req,
                 summary, description, email_recipient);
     }
 
+    struct buf buf = BUF_INITIALIZER;
+
     // Wrap the alert in a minimal JSCalendar Event.
+    buf_printf(&buf, "%d.%d", JSCAL_MAJOR_VERSION, JSCAL_MINOR_VERSION);
     json_t *jalerts = json_object();
     json_object_set(jalerts, id, jalert);
-    json_t *jevent = json_pack("{s:s s:s s:o}",
+    json_t *jevent = json_pack("{s:s s:s s:s s:o}",
                                "@type", "Event",
+                               "version", buf_cstring(&buf),
                                "start", "1970-01-01T00:00:00",
                                "alerts", jalerts);
+    buf_reset(&buf);
 
     jscal_cfg_t cfg = { 0 };
     cfg.emailalert_default_uri = email_recipient;
@@ -1292,6 +1297,7 @@ static icalcomponent *alert_to_ical(jmap_req_t *req,
 
     jmap_parser_fini(&myparser);
     json_decref(jevent);
+    buf_free(&buf);
     return valarm;
 }
 

--- a/imap/jmap_calendar_props.gperf
+++ b/imap/jmap_calendar_props.gperf
@@ -52,6 +52,7 @@ jmap_property_t;
 "calDavUrl",        JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "mailboxUniqueId",  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 "x-href",           JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
+"x-compactId",      JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 %%
 
 const jmap_prop_hash_table_t jmap_calendar_props_map = {

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -23,9 +23,6 @@
 #include "xcal.h"
 #include "xstrlcpy.h"
 
-#define JSCAL_MAJOR_VERSION 2
-#define JSCAL_MINOR_VERSION 0
-
 // ---------------
 
 #define myicalcomponent_foreach_component(comp, comp_kind, subcomp, iter)      \
@@ -3428,23 +3425,6 @@ static bool is_utcdatetime(json_t *jval)
     return is_valid;
 }
 
-static bool is_supported_version(json_t *jversion)
-{
-    const char *s = json_string_value(jversion);
-    if (!s) return false;
-
-    uint32_t major;
-    const char *p;
-    if (parseuint32(s, &p, &major) < 0) return false;
-    if (*p++ != '.') return false;
-
-    uint32_t minor;
-    if (parseuint32(p, &p, &minor) < 0) return false;
-    if (*p != '\0') return false;
-
-    return major == JSCAL_MAJOR_VERSION;
-}
-
 static bool is_vendorext_key(const char *key)
 {
     // TODO this check could be more thoroughly
@@ -4503,7 +4483,7 @@ static void validate_entry(jscal_ctx_t *ctx,
             if (!is_utcdatetime(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("version", key)) {
-            if (!is_supported_version(jval)) jmap_parser_invalid(parser, key);
+            // handled in validate_version
         }
         else if (!strcmp("virtualLocations", key)) {
             jmap_parser_push(parser, key);
@@ -4676,7 +4656,7 @@ static void validate_group(jscal_ctx_t *ctx,
             if (!is_utcdatetime(jval)) jmap_parser_invalid(parser, key);
         }
         else if (!strcmp("version", key)) {
-            if (!is_supported_version(jval)) jmap_parser_invalid(parser, key);
+            // handled in validate_version
         }
         // Extension properties
         else if (!strcmp("iCalendar", key)) {
@@ -4691,11 +4671,6 @@ static void validate_group(jscal_ctx_t *ctx,
 
     if (!json_object_get(jgroup, "entries"))
         jmap_parser_invalid(parser, "entries");
-
-    if (ctx->cfg.no_quirk && !json_object_get(jgroup, "version")) {
-        // We don't support version 1.0, aka RFC 8984.
-        jmap_parser_invalid(parser, "version");
-    }
 }
 
 static void group_to_ical(jscal_ctx_t *ctx,
@@ -4772,6 +4747,62 @@ static void group_to_ical(jscal_ctx_t *ctx,
     vendorexts_to_ical(ctx, jgroup, NULL, ical);
 }
 
+static void validate_version(jscal_ctx_t *ctx __attribute__((unused)),
+                             struct jmap_parser *parser,
+                             json_t *jobj)
+{
+    bool is_valid = false;
+
+    const char *version = json_string_value(json_object_get(jobj, "version"));
+    if (!version) goto done;
+
+    // Validate version number.
+    uint32_t major;
+    const char *p;
+    if (parseuint32(version, &p, &major) < 0) goto done;
+    if (*p++ != '.') goto done;
+
+    uint32_t minor;
+    if (parseuint32(p, &p, &minor) < 0) goto done;
+    if (*p != '\0') goto done;
+
+    // XXX we haven't fully fleshed out how to deal with JSCalendar data that
+    // is versioned higher than our supported version. The working assumption
+    // is that as the stewards of JSCalendar, we'll follow along all versions.
+    if (major != JSCAL_MAJOR_VERSION || minor > JSCAL_MINOR_VERSION)
+        goto done;
+
+    is_valid = true;
+
+    if (!strcmpsafe("Group", json_string_value(json_object_get(jobj, "@type"))))
+    {
+        /* draft-ietf-calext-jscalendarbis-16, Section 3.1.2:
+         *
+         * "For version "2.0" or higher, a Group object MUST set the "version"
+         * property, but the Event or Task objects that are values in its
+         * "entries" property MUST NOT set the "version" property. In contrast,
+         * an Event or Task object that is represented without an enclosing
+         * Group object MUST set the "version" property, unless specified
+         * otherwise. This is to prevent conflicting version values to occur
+         * in JSCalendar data."
+         */
+        json_t *jentry;
+        size_t i;
+        json_array_foreach(json_object_get(jobj, "entries"), i, jentry) {
+            if (json_object_get(jentry, "version")) {
+                jmap_parser_push_index(parser, "entries", i, NULL);
+                jmap_parser_invalid(parser, "version");
+                jmap_parser_pop(parser);
+            }
+        }
+    }
+
+done:
+    if (!is_valid) {
+        jmap_parser_invalid(parser, "version");
+    }
+}
+
 HIDDEN icalcomponent *jscal_to_ical(jscal_cfg_t *cfg,
                                     json_t *jobj,
                                     struct jmap_parser *parser)
@@ -4784,6 +4815,8 @@ HIDDEN icalcomponent *jscal_to_ical(jscal_cfg_t *cfg,
     if (!parser) parser = &myparser;
 
     icalcomponent *ical = NULL;
+
+    validate_version(&ctx, parser, jobj);
 
     const char *type = json_string_value(json_object_get(jobj, "@type"));
     if (!strcasecmpsafe(type, "Group")) {

--- a/imap/jscalendar.h
+++ b/imap/jscalendar.h
@@ -14,6 +14,9 @@ extern "C" {
 
 #include "jmap_util.h"
 
+#define JSCAL_MAJOR_VERSION 2 /**< The current JSCalendar major version. */
+#define JSCAL_MINOR_VERSION 0 /**< The current JSCalendar minor version. */
+
 /** @brief Configuration for JSCalendar/iCalendar conversion */
 typedef struct {
     /**


### PR DESCRIPTION
The jscalendarbis specification defines that the "version" property is mandatory for either a Group object, or an Event/Task object that is not an entry in a Group. Up until now, in quirk mode we allowed the version not being set. Now we strictly validate it.