### PR TITLE
jscalendar.c: do not set PRODID twice for Group and Event

### DIFF
--- a/cassandane/tiny-tests/Caldav/calendar_create_badname
+++ b/cassandane/tiny-tests/Caldav/calendar_create_badname
@@ -1,0 +1,19 @@
+#!perl
+use Cassandane::Tiny;
+
+sub test_calendar_create_badname ($self)
+{
+    my $CalDAV = $self->{caldav};
+
+    # Starts with 'C' and <= 12 chars long
+    my $res = $CalDAV->SafeRequest('MKCALENDAR', 'C0123456789A');
+    $self->assert_num_equals(403, $res->{http_response}{status});
+
+    # Starts with 'c' and <= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCOL', 'c01234567890A');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+
+    # Starts with 'C' and >= 12 chars long
+    $res = $CalDAV->SafeRequest('MKCALENDAR', 'C01234567890AB');
+    $self->assert_num_equals(201, $res->{http_response}{status});
+}

--- a/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_sharewith
+++ b/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_sharewith
@@ -105,7 +105,7 @@ sub test_calendar_set_sharewith
     my %map = @$acl;
     $self->assert_str_equals('lrswipkxtecdan9', $map{cassandane});
     $self->assert_str_equals('lrw59', $map{manifold});
-    $self->assert_str_equals('lrswitedn79', $map{paraphrase});
+    $self->assert_str_equals('lrwitedn79', $map{paraphrase});
 
     xlog $self, "check Outbox ACL";
     $acl = $admintalk->getacl("user.master.#calendars.Outbox");
@@ -131,7 +131,7 @@ sub test_calendar_set_sharewith
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
         $self->assert_str_equals('lrw', $map{manifold});
-        $self->assert_str_equals('lrswitedn', $map{paraphrase});
+        $self->assert_str_equals('lrwitedn', $map{paraphrase});
     }
 
     xlog $self, "Clear initial syslog";
@@ -157,8 +157,8 @@ sub test_calendar_set_sharewith
         $acl = $admintalk->getacl("user.master.#jmap");
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
-        $self->assert_str_equals('lrswitedn', $map{manifold});
-        $self->assert_str_equals('lrswitedn', $map{paraphrase});
+        $self->assert_str_equals('lrwitedn', $map{manifold});
+        $self->assert_str_equals('lrwitedn', $map{paraphrase});
     }
 
     xlog $self, "Remove the access for paraphrase";
@@ -180,7 +180,7 @@ sub test_calendar_set_sharewith
     $acl = $admintalk->getacl("user.master.#calendars.$CalendarId");
     %map = @$acl;
     $self->assert_str_equals('lrswipkxtecdan9', $map{cassandane});
-    $self->assert_str_equals('lrswitedn579', $map{manifold});
+    $self->assert_str_equals('lrwitedn579', $map{manifold});
     $self->assert_null($map{paraphrase});
 
     xlog $self, "check Outbox ACL";
@@ -207,7 +207,7 @@ sub test_calendar_set_sharewith
         $acl = $admintalk->getacl("user.master.#jmap");
         %map = @$acl;
         $self->assert_str_equals('lrswitedn', $map{cassandane});
-        $self->assert_str_equals('lrswitedn', $map{manifold});
+        $self->assert_str_equals('lrwitedn', $map{manifold});
         $self->assert_null($map{paraphrase});
     }
 }

--- a/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_sharewith_acl
+++ b/cassandane/tiny-tests/JMAPCalendarsRFC8984/calendar_set_sharewith_acl
@@ -115,7 +115,9 @@ sub test_calendar_set_sharewith_acl
         $self->assert_deep_equals(\%mergedrights,
             $res->[1][1]{list}[0]{shareWith}{zztester});
         my %acl = @{$admin->getacl("user.cassandane.#calendars.$mboxname")};
-        $self->assert_str_equals($_->{acl}, $acl{aatester});
-        $self->assert_str_equals($_->{acl}, $acl{zztester});
+
+        my $shared_acl = $_->{acl} =~ s/s//r;
+        $self->assert_str_equals($shared_acl, $acl{aatester});
+        $self->assert_str_equals($shared_acl, $acl{zztester});
     }
 }

--- a/imap/http_caldav.c
+++ b/imap/http_caldav.c
@@ -103,6 +103,7 @@ struct partial_caldata_t {
 static int meth_options_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_cal(struct transaction_t *txn, void *params);
 static int meth_get_head_fb(struct transaction_t *txn, void *params);
+static int meth_mkcalendar(struct transaction_t *txn, void *params);
 
 static void my_caldav_init(struct buf *serverinfo);
 static int my_caldav_auth(const char *userid);
@@ -618,8 +619,8 @@ struct namespace_t namespace_calendar = {
         { &meth_get_head_cal,   &caldav_params },       /* GET          */
         { &meth_get_head_cal,   &caldav_params },       /* HEAD         */
         { &meth_lock,           &caldav_params },       /* LOCK         */
-        { &meth_mkcol,          &caldav_params },       /* MKCALENDAR   */
-        { &meth_mkcol,          &caldav_params },       /* MKCOL        */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCALENDAR   */
+        { &meth_mkcalendar,     &caldav_params },       /* MKCOL        */
         { &meth_copy_move,      &caldav_params },       /* MOVE         */
         { &meth_options_cal,    &caldav_params },       /* OPTIONS      */
         { &meth_patch,          &caldav_params },       /* PATCH        */
@@ -2689,6 +2690,48 @@ static int caldav_get(struct transaction_t *txn, struct mailbox *mailbox,
 
     /* Unknown action */
     return HTTP_NO_CONTENT;
+}
+
+static int meth_mkcalendar(struct transaction_t *txn, void *params)
+{
+    int r = 0;
+
+    /* Parse the path (use our own entry to suppress lookup) */
+    txn->req_tgt.mbentry = mboxlist_entry_create();
+    r = caldav_parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+
+    /* Make sure method is allowed (only allowed on child of home-set) */
+    if (!txn->req_tgt.collection || txn->req_tgt.resource ||
+        (txn->req_tgt.collection[0] == 'C' &&
+         txn->req_tgt.collen <= CONV_JMAPID_SIZE + 1)) {
+        txn->error.precond = CALDAV_LOCATION_OK;
+        return HTTP_FORBIDDEN;
+    }
+    else if (r) {
+        switch (r) {
+        case IMAP_MAILBOX_EXISTS:
+            txn->error.precond = DAV_RES_EXISTS;
+            break;
+                
+        case IMAP_PERMISSION_DENIED:
+            txn->error.precond = DAV_NEED_PRIVS;
+            txn->error.rights = DACL_BIND;
+            buf_reset(&txn->buf);
+            buf_printf(&txn->buf, "%s/%s/%s",
+                       txn->req_tgt.namespace->prefix, USER_COLLECTION_PREFIX,
+                       txn->req_tgt.userid);
+            txn->error.resource = buf_cstring(&txn->buf);
+            break;
+                
+        default:
+            txn->error.precond = CALDAV_LOCATION_OK;
+            break;
+        }
+
+        return HTTP_FORBIDDEN;
+    }
+
+    return meth_mkcol(txn, params);
 }
 
 /* Perform post-create MKCOL/MKCALENDAR processing */

--- a/imap/http_dav.c
+++ b/imap/http_dav.c
@@ -5697,9 +5697,11 @@ int meth_mkcol(struct transaction_t *txn, void *params)
     /* Response should not be cached */
     txn->flags.cc |= CC_NOCACHE;
 
-    /* Parse the path (use our own entry to suppress lookup) */
-    txn->req_tgt.mbentry = mboxlist_entry_create();
-    r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    if (!txn->req_tgt.mbentry) {
+        /* Parse the path (use our own entry to suppress lookup) */
+        txn->req_tgt.mbentry = mboxlist_entry_create();
+        r = mparams->parse_path(txn->req_uri->path, &txn->req_tgt, &txn->error.desc);
+    }
 
     /* Make sure method is allowed (only allowed on child of home-set) */
     if (!txn->req_tgt.collection || txn->req_tgt.resource) {

--- a/imap/jmap_calendar.c
+++ b/imap/jmap_calendar.c
@@ -700,6 +700,14 @@ static int getcalendars_cb(const mbentry_t *mbentry, void *vrock)
         free(xhref);
     }
 
+    if (jmap_wantprop(rock->get->props, "x-compactId")) {
+        struct conversations_state cstate =
+            { .version = 2, .compact_emailids = 1 }; // force compactId
+        char compactid[JMAP_MAX_CALENDARID_SIZE];
+        jmap_set_calendarid(&cstate, mbentry, compactid);
+        json_object_set_new(obj, "x-compactId", json_string(compactid));
+    }
+    
     if (jmap_wantprop(rock->get->props, "name")) {
         buf_reset(&attrib);
         static const char *displayname_annot =

--- a/imap/jmap_calendar_props.gperf
+++ b/imap/jmap_calendar_props.gperf
@@ -52,6 +52,7 @@ jmap_property_t;
 "calDavUrl",        JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET | JMAP_PROP_EXTERNAL
 "mailboxUniqueId",  JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 "x-href",           JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
+"x-compactId",      JMAP_CALENDARS_EXTENSION, JMAP_PROP_SERVER_SET
 %%
 
 const jmap_prop_hash_table_t jmap_calendar_props_map = {

--- a/imap/jscalendar.c
+++ b/imap/jscalendar.c
@@ -4702,19 +4702,6 @@ static void group_to_ical(jscal_ctx_t *ctx,
                           json_t *jgroup,
                           icalcomponent *ical)
 {
-    json_t *jentries = json_object_get(jgroup, "entries");
-    json_t *jentry;
-    size_t i;
-    json_array_foreach(jentries, i, jentry)
-    {
-        entry_to_ical(ctx, jentry, ical);
-    }
-
-    categories_to_ical(ctx, jgroup, ical);
-    description_to_ical(ctx, jgroup, ical);
-    keywords_to_ical(ctx, jgroup, ical);
-    links_to_ical(ctx, jgroup, ical);
-
     json_t *jval;
 
     if (JNOTNULL(jval = json_object_get(jgroup, "color"))) {
@@ -4768,6 +4755,19 @@ static void group_to_ical(jscal_ctx_t *ctx,
         icaltimetype t = utctime_to_icaltime(json_string_value(jval));
         icalcomponent_add_property(ical, icalproperty_new_lastmodified(t));
     }
+
+    json_t *jentries = json_object_get(jgroup, "entries");
+    json_t *jentry;
+    size_t i;
+    json_array_foreach(jentries, i, jentry)
+    {
+        entry_to_ical(ctx, jentry, ical);
+    }
+
+    categories_to_ical(ctx, jgroup, ical);
+    description_to_ical(ctx, jgroup, ical);
+    keywords_to_ical(ctx, jgroup, ical);
+    links_to_ical(ctx, jgroup, ical);
 
     vendorexts_to_ical(ctx, jgroup, NULL, ical);
 }


### PR DESCRIPTION
This fixes a bug where the PRODID property in a VCALENDAR component was set twice if both the Group and at least one Event object had the prodId property set. The fix is to convert first the Group properties, then its entries.

This bug doesn't show up in JMAP Calendars because we do not allow to set Group objects there. But it did show up in the tests of the draft-ietf-calext-jscalendar-icalendar draft. We'll port the tests of the RFC document to Cassandane soon, which also will then serve as regression test.